### PR TITLE
Updated DataCamel to include script refactoring changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,7 +147,6 @@ csx/
 AppPackages/
 
 # Others
-sql/
 *.Cache
 ClientBin/
 [Ss]tyle[Cc]op.*

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/App/Options.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/App/Options.cs
@@ -51,7 +51,7 @@ namespace DataCamel.App
 
 ");
             var version = Assembly.GetExecutingAssembly().GetName().Version;
-            heading.AppendLine(string.Format("DataCamel {0}.{1}.{2}", version.Major, version.Minor, version.Revision));
+            heading.AppendLine(string.Format("DataCamel {0}.{1}.{2}", version.Major, version.Minor, version.Build));
             heading.AppendLine("Copyright c 2015 FTI Consulting");
 
             return heading.ToString();

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/App/Upgrader.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/App/Upgrader.cs
@@ -39,13 +39,13 @@ namespace DataCamel.App
             string prefix = "SQL Component_v";
             DirectoryInfo di = new DirectoryInfo(options.InstallPath);
             var dirs = di.GetDirectories(prefix + options.Version, SearchOption.TopDirectoryOnly);
-            
-            if(dirs.Length != 1)
+
+            if (dirs.Length != 1)
                 return false;
             else
                 return true;
         }
-        
+
 
         public void UpgradeDatabases(Options options)
         {
@@ -82,7 +82,7 @@ namespace DataCamel.App
         {
             try
             {
-                if(! async) Logger(string.Format("Updating database '{0}'... ", database));
+                if (!async) Logger(string.Format("Updating database '{0}'... ", database));
                 else Logger(string.Format("Starting update for database '{0}'\r\n", database));
 
                 string connStr = string.Format("Data Source={0};Initial Catalog={1};User Id={2};Password={3}", options.Server, "master", options.Username, options.Password);
@@ -96,8 +96,7 @@ namespace DataCamel.App
                     command.CommandType = System.Data.CommandType.StoredProcedure;
                     command.Parameters.AddWithValue("@database_name", database);
                     command.Parameters.AddWithValue("@username", options.Username);
-                    command.Parameters.AddWithValue("@password", options.Password);
-                    command.Parameters.AddWithValue(@"@ringtail_database_model", options.Version);
+                    command.Parameters.AddWithValue("@ringtail_app_version", options.Version);
                     command.ExecuteNonQuery();
                 }
                 if (!async) Logger("Complete\r\n");

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Properties/AssemblyInfo.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("93d223dc-e2ea-4059-be2a-13016cbc6556")]
 
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rf_directory_slash.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rf_directory_slash.sql
@@ -1,0 +1,94 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if exists (select 1 from information_schema.routines where routine_name = 'rf_directory_slash' and routine_schema = 'dbo')
+begin
+    drop function dbo.rf_directory_slash
+end
+go
+
+create function dbo.rf_directory_slash 
+	(
+		 @beginning_slash varchar(3)
+		,@directory varchar(max)
+		,@ending_slash varchar(3)
+	)
+	returns varchar(max)
+with encryption
+as
+begin
+    select
+		 @beginning_slash = isnull(@beginning_slash, '')
+		,@directory = isnull(@directory, '')
+		,@ending_slash = isnull(@ending_slash, '')
+
+    --remove all slashes from beginning
+    while left(@directory, 1) in ('\', '/')
+    begin
+        set @directory = right(@directory, len(@directory) - 1)
+    end
+
+    --remove all slashes from end
+    while right(@directory, 1) in ('\', '/')
+    begin
+        set @directory = left(@directory, len(@directory) - 1)
+    end
+
+    --add slashes
+    return @beginning_slash + @directory + @ending_slash
+end
+
+go
+
+
+/*
+
+Returns a folder with the slash format that you want. It first removes all slashes from the beginning and end and then adds back the slash format you specify.
+
+Syntax:
+	dbo.rf_directory_slash(@beginning_slash, @directory, @ending_slash)
+
+Arguments:
+    @beginning_slash - varchar(3)
+        Any non-unicode string
+    @directory - varchar(max)
+        The folder or directory that you want to re-format.
+    @ending_slash - varchar(3)
+        Any non-unicode string
+
+Returns:
+    varchar(max)
+
+Examples:
+    set nocount on
+
+    --Remove the beginning slash
+    select master.dbo.rf_directory_slash(null, '\folder_name_a\folder_name_b\', '\')
+
+    --Remove the ending slash
+    select master.dbo.rf_directory_slash('\', '\folder_name_a\folder_name_b\', null)
+
+    --Remove both
+    select master.dbo.rf_directory_slash(null, '\folder_name_a\folder_name_b\', null)
+
+    --Add both #1 (ensures that they are there when you aren't sure of the input)
+    select master.dbo.rf_directory_slash('\', '\folder_name_a\folder_name_b\', '\')
+
+    --Add both #2 (ensures that they are there when you aren't sure of the input)
+    select master.dbo.rf_directory_slash('\', 'folder_name_a\folder_name_b', '\')
+
+    --Add multiple slashes
+    select master.dbo.rf_directory_slash('\\', 'folder_name_a\folder_name_b', '\\\')
+
+    --Remove multiple slashes
+    select master.dbo.rf_directory_slash('\', '\\\folder_name_a\folder_name_b\\', '\')
+
+    set nocount off
+
+*/
+
+go

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rf_split_8k_string_single_delimiter.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rf_split_8k_string_single_delimiter.sql
@@ -1,0 +1,72 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if exists (select 1 from information_schema.routines where routine_name = 'rf_split_8k_string_single_delimiter' and routine_schema = 'dbo')
+begin
+    drop function dbo.rf_split_8k_string_single_delimiter
+end
+go
+
+create function dbo.rf_split_8k_string_single_delimiter
+(
+     @string varchar(8000)
+    ,@delimiter char(1) = ','
+)
+--WARNING!!! DO NOT USE MAX DATA-TYPES HERE!  IT WILL KILL PERFORMANCE!
+returns table with schemabinding as
+return
+
+/*
+Taken from Jeff Moden's article:
+http://www.sqlservercentral.com/articles/Tally+Table/72993/
+*/
+
+with e1(n) as
+( -- 10E+1 or 10 rows
+    select 1 union all select 1 union all select 1 union all
+    select 1 union all select 1 union all select 1 union all
+    select 1 union all select 1 union all select 1 union all select 1
+)
+,e2(n) as
+( -- 10E+2 or 100 rows
+    select 1 from e1 a, e1 b
+)
+,e4(n) as
+( -- 10E+4 or 10,000 rows max
+    select 1 from e2 a, e2 b
+)
+,cteTally(n) as
+( -- This provides the base CTE and limits the number of rows right up front for both a performance gain and prevention of accidental overruns
+    select top (isnull(datalength(@string),0)) row_number() over (order by (select null)) from e4
+),
+cteStart(n1) as
+( -- This returns N+1 (starting position of each element just once for each delimiter)
+    select 1 union all
+    select t.n + 1 from cteTally t where substring(@string, t.n, 1) = @delimiter
+),
+cteLen(n1, l1) as
+( -- Return start and length (for use in substring)
+    select s.n1, isnull(nullif(charindex(@delimiter, @string, s.n1), 0) - s.n1, 8000)
+    from cteStart s
+)
+-- Do the actual split. The ISNULLNULLIF combo handles the length for the final element when no delimiter is found.
+select
+     ItemNumber = row_number() over(order by l.n1)
+    ,item = substring(@string, l.n1, l.l1)
+from cteLen l;
+
+go
+
+/*
+
+declare
+     @string varchar(8000) = 'D:\temp\temp_1.sql,D:\temp\temp_2.sql,D:\temp\temp_3.sql'
+    ,@delimiter char(1) = ','
+
+select * from dbo.rf_split_8k_string_single_delimiter(@string, @delimiter)
+
+*/

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_backup.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_backup.sql
@@ -1,0 +1,180 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_case_backup') is not null
+begin
+    drop procedure dbo.rp_case_backup
+end
+go
+
+create procedure dbo.rp_case_backup
+(
+     @database_name nvarchar(128)       -- [Required] Actual database name that you are backing up (e.g., Longford).
+    ,@full_path nvarchar(4000)  = null  -- [Optional] The full path to the .bak file (e.g., D:\SQL\Backups\Longford.bak). If not supplied we will use the default.
+    ,@overwrite bit = 0                 -- [Optional] If a backup exists with the same name, Overwrite = 0 will append this backup to that one otherwise it will overwrite it.
+    ,@name nvarchar(128) = null         -- [Optional] Name of the backup set. This is what you see in the SSMS UI.
+    ,@description nvarchar(255) = null  -- [Optional] Describes the backup set. This is NOT seen in the SSMS UI.
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+set xact_abort on
+set transaction isolation level read uncommitted
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] START'
+
+declare
+     @return int = 0
+    ,@sql nvarchar(1000)
+    ,@sql_params nvarchar(100)
+    ,@ringtail_app_version nvarchar(25)
+    ,@ringtail_db_version nvarchar(25)
+    ,@directory nvarchar(4000) -- Directory only
+
+--====================================================================================================
+
+if not exists (select 1 from sys.databases where name = @database_name)
+begin
+    set @return = -1
+    raiserror('Database [%s] does not exist on this server.', 16, 1, @database_name)
+    return @return
+end
+
+--====================================================================================================
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] Getting app and db version numbers on database [' + @database_name + ']'
+
+select
+     @sql_params = N'@ringtail_app_version nvarchar(25) output, @ringtail_db_version nvarchar(25) output'
+    ,@sql = N'
+    use [<<@database_name>>]
+    if exists (select 1 from dbo.list_variables)
+    begin
+        select @ringtail_app_version = ltrim(rtrim(thevalue)) from dbo.list_variables where thelabel = ''RingtailApplicationVersion'';
+        select @ringtail_db_version = ltrim(rtrim(thevalue)) from dbo.list_variables where thelabel = ''RingtailDatabaseModel'';
+    end
+    '
+    ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+
+if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] @sql: ' + isnull(@sql, '{null}')
+
+exec sp_executesql
+     @sql, @sql_params
+    ,@ringtail_app_version = @ringtail_app_version output
+    ,@ringtail_db_version = @ringtail_db_version output
+
+if @debug >= 2
+begin
+    print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] @ringtail_app_version: ' + isnull(@ringtail_app_version, '{null}')
+    print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] @ringtail_db_version: ' + isnull(@ringtail_db_version, '{null}')
+end
+
+--====================================================================================================
+
+-- Create strings
+
+select
+     @name = case when datalength(@name) > 0 then @name + N' - ' else N'' end
+    ,@name = @name + N'App (<<@ringtail_app_version>>); DB (<<@ringtail_db_version>>)'
+    ,@name = replace(@name, '<<@ringtail_app_version>>', @ringtail_app_version)
+    ,@name = replace(@name, '<<@ringtail_db_version>>', @ringtail_db_version)
+
+    ,@description = case when datalength(@description) > 0 then @description + N' - ' else N'' end
+    ,@description = @description + N'Date (<<@date>>); Server (<<@server>>)'
+    ,@description = replace(@description, '<<@date>>', convert(varchar(23), getdate(), 121))
+    ,@description = replace(@description, '<<@server>>', @@servername)
+
+if @debug >= 2
+begin
+    print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] @name: ' + isnull(@name, '{null}')
+    print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] @description: ' + isnull(@description, '{null}')
+end
+
+--====================================================================================================
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] Validating backup path'
+
+if nullif(@full_path, '') is null -- The .bak name wasn't supplied either
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] @full_path was empty. Checking registry for default location.'
+
+    exec master.dbo.xp_instance_regread N'HKEY_LOCAL_MACHINE', N'Software\Microsoft\MSSQLServer\MSSQLServer', N'BackupDirectory', @full_path output, 'no_output'
+
+    set @directory = @full_path
+
+    -- Now add @database_name and .bak to the @full_path
+    set @full_path = @full_path + N'\' + @database_name + N'.bak'
+end
+else
+begin
+    -- Remove the database name and extension (since they won't exist on the first backup) and just validate the directory. If @full_path wasn't supplied then this step isn't necessary.
+    set @directory = substring(@full_path, 1, len(@full_path) - charindex('\', reverse(@full_path)))
+end
+
+exec @return = master.dbo.rp_validate_path
+     @path = @directory
+    ,@debug = @debug
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] Backing up database [' + @database_name + '] to ' + @full_path
+
+--====================================================================================================
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] Backing up database [' + @database_name + ']'
+
+select
+     @sql = 'BACKUP DATABASE [<<@database_name>>] TO DISK = N''<<@full_path>>'' WITH DESCRIPTION = N''<<@description>>'', NOFORMAT, <<@init_noinit>>,  NAME = N''<<@name>>'', SKIP, NOREWIND, NOUNLOAD, STATS = 10'
+    ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+    ,@sql = replace(@sql, '<<@full_path>>', @full_path)
+    ,@sql = replace(@sql, '<<@description>>', @description)
+    ,@sql = replace(@sql, '<<@init_noinit>>', case @overwrite when 1 then 'INIT' else 'NOINIT' end)
+    ,@sql = replace(@sql, '<<@name>>', @name)
+
+if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] @sql: ' + isnull(@sql, '{null}')
+
+exec sp_executesql @sql
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_backup] END'
+
+return @return
+
+go
+
+grant exec on dbo.rp_case_backup to public
+go
+
+/* DEV TESTING
+
+-- Backup Longford to "foo.bak"
+exec master.dbo.rp_case_backup
+     @database_name = 'Longford'
+    ,@full_path = 'D:\SQL\Backup\foo.bak'
+    ,@overwrite = 0
+    ,@name = N'Longford'
+    ,@description = N'I said, Longford!'
+    ,@debug = 3
+
+-- Restore "foo.bak" as "asfubjghhaifuvbh"
+exec master.dbo.rp_case_restore
+     @database_name = 'asfubjghhaifuvbh'
+    ,@full_path = 'D:\SQL\Backup\foo.bak'
+    ,@debug = 3
+
+-- Drop "asfubjghhaifuvbh"
+exec master.dbo.rp_case_drop
+     @database_name = 'asfubjghhaifuvbh'
+    ,@debug = 3
+
+*/

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_create.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_create.sql
@@ -1,0 +1,246 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_case_create') is not null
+begin
+    drop procedure dbo.rp_case_create
+end
+go
+
+create procedure dbo.rp_case_create
+(
+     @database_name nvarchar(128)               -- [Required] If the database doesn't exist then we'll call rp_case_create.
+    ,@sql_data_directory nvarchar(500) = null   -- [Optional] Will use server default if not passed in.
+    ,@sql_log_directory nvarchar(500) = null    -- [Optional] Will use server default if not passed in.
+    ,@username nvarchar(128)                    -- [Required] This is needed for the create script.
+    ,@ringtail_app_version varchar(25) = null   -- [Optional] If null then we'll use the most recent SQL Components
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+set xact_abort on
+set transaction isolation level read uncommitted
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] START'
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+declare
+     @return int = 0
+    ,@sql_component_path nvarchar(2000)
+    ,@sql nvarchar(max)
+    ,@default_data_path nvarchar(4000)
+    ,@default_log_path nvarchar(4000)
+    ,@database_name_ce nvarchar(128) = @database_name + N'_CE'
+    ,@database_name_dw nvarchar(128) = @database_name + N'_DW'
+
+-- Handle zero-length (empty) strings
+select
+     @ringtail_app_version = nullif(@ringtail_app_version, '')
+    ,@sql_data_directory = nullif(@sql_data_directory, N'')
+    ,@sql_log_directory = nullif(@sql_log_directory, N'')
+
+--====================================================================================================
+
+/* Don't try to run this on a CE or DW database */
+
+if @database_name like '%[_]CE' or @database_name like '%[_]DW'
+begin
+    set @return = -1
+    raiserror('Database [%s] can not be created directly. Create the Case instead and it will create the _CE and _DW databases.', 16, 1, @database_name)
+    return @return
+end
+
+--====================================================================================================
+
+/* If the database exists we will upgrade it instead. If not, delete any CE or DW databases that may still be around. */
+
+if exists (select 1 from sys.databases where name = @database_name)
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] [' + @database_name + '] already exists. Running rp_case_upgrade.'
+
+    exec master.dbo.rp_case_upgrade
+         @database_name = @database_name
+        ,@username = @username
+        ,@ringtail_app_version = @ringtail_app_version
+        ,@debug = @debug
+
+    return @return
+end
+else
+begin
+    /* Drop CE and DW databases */
+
+    if exists (select 1 from sys.databases where name = @database_name_ce)
+    begin
+        if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] Running rp_case_drop on database [' + @database_name_ce + ']'
+
+        exec master.dbo.rp_case_drop
+             @database_name = @database_name_ce
+            ,@debug = @debug
+    end
+    
+    if exists (select 1 from sys.databases where name = @database_name_dw)
+    begin
+        if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] Running rp_case_drop on database [' + @database_name_dw + ']'
+
+        exec master.dbo.rp_case_drop
+             @database_name = @database_name_dw
+            ,@debug = @debug
+    end
+end
+
+--====================================================================================================
+
+/* Since @ringtail_app_version is null go find the latest version. */
+
+if @ringtail_app_version is null
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] Running rp_get_sql_components.'
+
+    exec master.dbo.rp_get_sql_components
+         @sql_component_path = @sql_component_path output
+        ,@ringtail_app_version = @ringtail_app_version output
+        ,@debug = @debug
+
+    if @sql_component_path is null
+    begin
+        raiserror('Could not find a valid SQL Component path.', 16, 1)
+        return @return
+    end
+end
+
+--====================================================================================================
+
+if @sql_data_directory is null or @sql_log_directory is null
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] Find the default data and log paths'
+
+    exec master.dbo.rp_get_default_database_location
+         @default_data_path = @default_data_path output
+        ,@default_log_path = @default_log_path output
+        ,@debug = @debug
+
+    if @sql_data_directory is null set @sql_data_directory = @default_data_path
+    if @sql_log_directory is null set @sql_log_directory = @default_log_path
+
+    if @debug >= 1
+    begin
+        print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] @sql_data_directory: ' + isnull(@sql_data_directory, N'{null}')
+        print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] @sql_log_directory: ' + isnull(@sql_log_directory, N'{null}')
+    end
+end
+
+
+--====================================================================================================
+
+/* Create new case */
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] Creating database [' + @database_name + ']'
+
+select
+     @sql = 'create database [<<@database_name>>] on primary (name = ''<<@database_name>>'', filename = N''<<@sql_data_directory>><<@database_name>>.mdf'', size = 262144KB, filegrowth = 20%) log on (name = ''<<@database_name>>_log'', filename = N''<<@sql_log_directory>><<@database_name>>_log.ldf'', size = 131072KB, filegrowth = 20%) with trustworthy on;'
+    ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+    ,@sql = replace(@sql, N'<<@sql_data_directory>>', master.dbo.rf_directory_slash(null, @sql_data_directory, N'\'))
+    ,@sql = replace(@sql, N'<<@sql_log_directory>>', master.dbo.rf_directory_slash(null, @sql_log_directory, N'\'))
+
+if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] @sql: ' + isnull(@sql, '{null}')
+
+exec sp_executesql @sql
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] Finished creating database [' + @database_name + ']'
+
+--====================================================================================================
+
+/* Install the Bootstrap procedures */
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] Running rp_install_bootstrap on database [' + @database_name + '] with @ringtail_app_version [' + @ringtail_app_version + ']'
+
+exec master.dbo.rp_install_bootstrap
+     @database_name = @database_name
+    ,@ringtail_app_version = @ringtail_app_version
+    ,@sql_component_path = @sql_component_path
+    ,@debug = @debug
+
+--====================================================================================================
+
+/* Install Ringtail scripts */
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] Installing Ringtail scripts on database [' + @database_name + ']'
+
+set @sql = N'
+use [<<@database_name>>];
+
+declare @dbType varchar(40), @path varchar(400), @reference xml, @ringtailModel varchar(255)
+
+set @reference = ''<reference>
+    <targetpath>C:\Program Files\Ringtail\SQL Component_v<<@ringtail_app_version>>\Scripts\Case</targetpath>
+    <substitution>
+        <s x="$(dbUser)" y="<<@username>>"/>
+        <s x="$(mdfSize)" y="250mb"/>
+        <s x="$(mdfGrowth)" y="20%"/>
+        <s x="$(ldfSize)" y="120mb"/>
+        <s x="$(ldfGrowth)" y="20%"/>
+        <s x="$(portalAdminUser)" y="admin"/>
+        <s x="$(portalAdminPwd)" y="admin"/>
+    </substitution>
+    </reference>''
+
+exec dbo.rs_sp_database__upgrade @reference
+
+select ''<<@database_name>> after create/install'' as ''<<@database_name>> after create/install'', * from dbo.list_variables where thelabel in (''dbModel'',''dbScriptModel'',''RingtailApplicationVersion'');
+'
+
+select
+     @sql = replace(@sql, '<<@database_name>>', @database_name)
+    ,@sql = replace(@sql, '<<@ringtail_app_version>>', @ringtail_app_version)
+    ,@sql = replace(@sql, '<<@username>>', @username)
+
+if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] @sql: ' + isnull(@sql, '{null}')
+
+if @debug <> 255
+    exec sp_executesql @sql
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_create] END'
+
+return @return
+
+go
+
+grant exec on dbo.rp_case_create to public
+go
+
+/* DEV TESTING
+
+exec master.dbo.rp_case_drop
+     @database_name = 'eyjnhdafb fsazdf'
+    ,@debug = 1
+
+exec master.dbo.rp_case_drop
+     @database_name = 'eyjnhdafb fsazdf_DW'
+    ,@debug = 1
+
+exec master.dbo.rp_case_drop
+     @database_name = 'eyjnhdafb fsazdf_CW'
+    ,@debug = 1
+
+exec master.dbo.rp_case_create
+     @database_name = 'eyjnhdafb fsazdf'
+    ,@sql_data_directory = N'D:\SQL\SQL2014\Data'
+    ,@sql_log_directory = N'D:\SQL\SQL2014\Log'
+    ,@username = 'webuser'
+    ,@ringtail_app_version = null
+    ,@debug = 9
+
+*/

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_custom_scripts.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_custom_scripts.sql
@@ -1,0 +1,281 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_case_custom_scripts') is not null
+begin
+    drop procedure dbo.rp_case_custom_scripts
+end
+go
+
+create procedure dbo.rp_case_custom_scripts
+(
+     @database_name nvarchar(128)                   -- [Required] Does not have to be the same name as the backup. You can restore a Longford.bak file as a database named "PaulHogan" if you want.
+    ,@set_simple_recovery bit = 0                   -- [Optional] Changes the database to simple recovery mode for better performance.
+    ,@shrink_log_file bit = 0                       -- [Optional] Shrinks the log file after setting simple recovery to reduce file size on disk.
+    ,@set_trustworthy bit = 0                       -- [Optional] Changes the database to trustworthy.
+    ,@disable_auditdata_and_fieldlocking bit = 0    -- [Optional] Disables the audit data triggers and field_locking triggers.
+    ,@enable_agent_access bit = 0                   -- [Optional] Enables the Validate Agent Access list_variable
+    ,@enable_ingestions bit = 0                     -- [Optional] Enables the Ingestions list_variable
+    ,@rollback_version_numbers bit = 0              -- [Optional] Will rollback the database version numbers to 8.000.0000 for you.
+    ,@rebuild_fulltext_indexes bit = 0              -- [Optional] Fixes problems with full-text population
+    ,@reset_all_passwords_to varchar(25) = null     -- [Optional] Resets everyone's password, sets password_changed and last_login_attempt to getdate(), 
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+set xact_abort on
+set transaction isolation level read uncommitted
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] START'
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+declare
+     @return int = 0
+    ,@sql nvarchar(max)
+    ,@is_ce bit = 0
+    ,@is_dw bit = 0
+
+if not exists (select 1 from sys.databases where name = @database_name)
+begin
+    raiserror('Database [%s] does not exist.', 16, 1, @database_name)
+    return -1
+end
+
+if right(@database_name, 3) = '_CE' set @is_ce = 1
+if right(@database_name, 3) = '_DW' set @is_dw = 1
+
+--====================================================================================================
+
+if @set_simple_recovery = 1
+begin
+    if not exists (select 1 from sys.databases where recovery_model = 3 and name = @database_name)
+    begin
+        if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] Changing database [' + @database_name + '] to SIMPLE recovery model'
+
+        select
+             @sql = 'ALTER DATABASE [<<@database_name>>] SET RECOVERY SIMPLE WITH NO_WAIT'
+            ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+
+        if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] @sql: ' + isnull(@sql, N'{null}')
+
+        exec sp_executesql @sql
+    end
+end
+
+--====================================================================================================
+
+/* This doesn't work yet.
+
+if @shrink_log_file = 1
+begin
+    if not exists (select 1 from sys.databases where recovery_model = 3 and name = @database_name)
+    begin
+        if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] Shrinking log file on database [' + @database_name + ']'
+
+        select
+             @sql = 'DBCC SHRINKFILE (N''<<@log_name>>'', 0, TRUNCATEONLY)'
+            ,@sql = replace(@sql, '<<@log_name>>', @log_name)
+
+        if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] @sql: ' + isnull(@sql, N'{null}')
+
+        exec sp_executesql @sql
+    end
+end
+
+*/
+
+--====================================================================================================
+
+if @set_trustworthy = 1
+begin
+    if not exists (select 1 from sys.databases where is_trustworthy_on = 1 and name = @database_name)
+    begin
+        if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] Setting database [' + @database_name + '] to TRUSTWORTHY'
+
+        select
+             @sql = 'ALTER DATABASE [<<@database_name>>] SET TRUSTWORTHY ON'
+            ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+
+        if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] @sql: ' + isnull(@sql, N'{null}')
+
+        exec sp_executesql @sql
+    end
+end
+
+--====================================================================================================
+
+if @disable_auditdata_and_fieldlocking = 1 and @is_ce = 0 and @is_dw = 0
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] Disabling audit data triggers on database [' + @database_name + ']'
+
+    set @sql = '
+    use [<<@database_name>>]
+
+    declare @sql nvarchar(max)
+
+    if exists (select 1 from sys.tables where name = ''fti_tb_AD_xref'')
+    begin
+        -- Set all of the tables to disabled
+        update dbo.fti_tb_AD_xref set state_id = 0
+    end
+
+    -- Reset the archive database name to handle cases where the DB was restored as a different name.
+    if exists (select 1 from sys.tables where name = ''fti_tb_TL_config'')
+    begin
+        update dbo.fti_tb_TL_config set config_value = ''<<@database_name>>_Archive'' where config_name = ''archive_db_name''
+    end
+
+    if exists (select 1 from sys.databases where name = ''<<@database_name>>_Archive'')
+    begin
+        -- This should turn off Audit Data
+        if exists (select 1 from sys.procedures where name = ''fti_sp_AD_reinitialize_archiving_tables_and_triggers_create'')
+        begin
+            exec dbo.fti_sp_AD_reinitialize_archiving_tables_and_triggers_create
+        end
+    end
+
+    -- But just in case the above step did not work...this will drop Audit Data and also Field Locking triggers
+    -- You can not just disable the triggers since there are post processing scripts that inadvertantly turn them back on
+    while 1=1
+    begin
+        select top 1 @sql = ''drop trigger '' + name
+        from sys.triggers
+        where is_disabled = 0 
+        and (name like ''fti[_]tr[_]AD[_]%'' or name like ''fti[_]fr[_]FL[_]%'')
+
+        if @@rowcount = 0
+            break
+
+        --print @sql
+
+        exec sp_executesql @sql
+    end'
+
+    set @sql = replace(@sql, '<<@database_name>>', @database_name)
+
+    if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] @sql: ' + isnull(@sql, N'{null}')
+
+    exec sp_executesql @sql
+end
+
+--====================================================================================================
+
+if @enable_agent_access = 1 and @is_ce = 0 and @is_dw = 0
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] Set ''Validate Agent Path Access'' to False on database [' + @database_name + ']'
+
+    select
+         @sql = 'if exists (select 1 from [<<@database_name>>].dbo.list_variables) begin update [<<@database_name>>].dbo.list_variables set thevalue = ''False'' where thelabel = ''Validate Agent Path Access'' end'
+        ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+
+    if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] @sql: ' + isnull(@sql, N'{null}')
+
+    exec sp_executesql @sql
+end
+
+--====================================================================================================
+
+if @enable_ingestions = 1 and @is_ce = 0 and @is_dw = 0
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] Set ''Enable_Ingestion'' to True on database [' + @database_name + ']'
+
+    select
+         @sql = 'if exists (select 1 from [<<@database_name>>].dbo.list_variables) begin update [<<@database_name>>].dbo.list_variables set theValue = 1 where theLabel = ''Enable_Ingestion'' end'
+        ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+
+    if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] @sql: ' + isnull(@sql, N'{null}')
+
+    exec sp_executesql @sql
+
+    -- update portal.dbo.list_variables set thevalue = '172.30.99.91' where thelabel = 'IngestionLicensingServer'
+end
+
+--====================================================================================================
+
+if @rollback_version_numbers = 1
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] Rolling back version numbers to 08.0000.0000 on database [' + @database_name + ']'
+
+    select
+        @sql = '
+        use [<<@database_name>>];
+        
+        if exists (select 1 from dbo.list_variables)
+        begin
+            declare @version varchar(25)
+            select @version = thevalue from dbo.list_variables where thelabel = ''dbScriptModel''
+            update dbo.list_variables set theValue = replace(thevalue, @version, ''08.0000.0000'') where theLabel in (''dbModel'', ''dbScriptModel'', ''RingtailDatabaseModel'')
+        end'
+        ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+
+    if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] @sql: ' + isnull(@sql, N'{null}')
+
+    exec sp_executesql @sql
+end
+
+--====================================================================================================
+
+if @rebuild_fulltext_indexes = 1 and @is_ce = 0 and @is_dw = 0
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] Fix full-text population errors on database [' + @database_name + ']'
+
+    select
+         @sql = 'use [<<@database_name>>]; if exists (select 1 from sys.fulltext_catalogs where name = ''OtherTables'') begin ALTER FULLTEXT CATALOG OtherTables REBUILD end;'
+        ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+
+    if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] @sql: ' + isnull(@sql, N'{null}')
+
+    exec sp_executesql @sql
+end
+
+if nullif(@reset_all_passwords_to, '') is not null and @is_ce = 0 and @is_dw = 0
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] Reset all passwords on database [' + @database_name + '] to [' + @reset_all_passwords_to + ']'
+
+    select
+         @sql = 'use [<<@database_name>>]; if exists (select 1 from sys.tables where name = ''list_users'') update dbo.list_users set password = pwdencrypt(<<@reset_all_passwords_to>>), login_attempts = 0, password_changed = getdate(), last_login_attempt = getdate();'
+        ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+        ,@sql = replace(@sql, '<<@reset_all_passwords_to>>', @reset_all_passwords_to)
+
+    if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] @sql: ' + isnull(@sql, N'{null}')
+
+    exec sp_executesql @sql
+end
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_custom_scripts] END'
+
+return @return
+
+go
+
+grant exec on dbo.rp_case_custom_scripts to public
+go
+
+/* DEV TESTING
+
+exec master.dbo.rp_case_custom_scripts
+     @database_name = 'RestoreTesting'
+    ,@set_simple_recovery = 1
+    ,@shrink_log_file = 0
+    ,@set_trustworthy = 1
+    ,@disable_auditdata_and_fieldlocking = 1
+    ,@enable_agent_access = 1
+    ,@enable_ingestions = 1
+    ,@rollback_version_numbers = 0
+    ,@rebuild_fulltext_indexes = 0
+    ,@reset_all_passwords_to = '!password1'
+    ,@debug = 9
+
+*/

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_drop.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_drop.sql
@@ -1,0 +1,96 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_case_drop') is not null
+begin
+    drop procedure dbo.rp_case_drop
+end
+go
+
+create procedure dbo.rp_case_drop
+(
+     @database_name nvarchar(128) -- [Required]
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+set xact_abort on
+set transaction isolation level read uncommitted
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_drop] START'
+
+declare
+     @return int = 0
+    ,@sql nvarchar(500)
+
+if exists (select 1 from sys.databases where name = @database_name)
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_drop] Setting SINGLE_USER mode on database [' + @database_name + ']'
+
+    set @sql = 'ALTER DATABASE [' + @database_name + '] SET SINGLE_USER WITH ROLLBACK IMMEDIATE'
+
+    if @debug >= 3 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_drop] @sql: ' + isnull(@sql, '{null}')
+
+    begin try
+        exec @return = sp_executesql @sql
+    end try
+    begin catch
+        raiserror('Error setting SINGLE_USER mode.', 16, 1)
+        return @return
+    end catch
+
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_drop] Dropping database [' + @database_name + ']'
+
+    set @sql = 'DROP DATABASE [' + @database_name + ']'
+
+    if @debug >= 3 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_drop] @sql: ' + isnull(@sql, '{null}')
+
+    begin try
+        exec @return = sp_executesql @sql
+    end try
+    begin catch
+        set @sql = 'ALTER DATABASE [' + @database_name + '] SET MULTI_USER'
+
+        exec @return = sp_executesql @sql
+
+        raiserror('Error dropping database.', 16, 1)
+        return @return
+    end catch
+end
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_drop] END'
+
+return @return
+
+go
+
+grant exec on dbo.rp_case_drop to public
+go
+
+/* DEV TESTING
+
+create database foo
+
+select * from sys.databases where name = 'foo'
+
+exec master.dbo.rp_case_drop
+     @database_name = 'foo'
+    ,@debug = 9
+
+select * from sys.databases where name = 'foo'
+
+*/
+

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_restore.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_restore.sql
@@ -1,0 +1,332 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_case_restore') is not null
+begin
+    drop procedure dbo.rp_case_restore
+end
+go
+
+create procedure dbo.rp_case_restore
+(
+     @database_name nvarchar(128)               -- [Required] Does not have to be the same name as the backup. You can restore a Longford.bak file as a database named "PaulHogan" if you want.
+    ,@full_path nvarchar(4000)                  -- [Required] The full path to the .bak file (e.g., D:\SQL\Backups\Longford.bak)
+    ,@sql_data_directory nvarchar(500) = null   -- [Optional] Will use server default if not passed in.
+    ,@sql_log_directory nvarchar(500) = null    -- [Optional] Will use server default if not passed in.
+    ,@sql_ft_directory nvarchar(500) = null     -- [Optional] Will use server default if not passed in.
+    ,@file_number tinyint = null                -- [Optional] Will use the max(file_number) if not passed in.
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+set xact_abort on
+set transaction isolation level read uncommitted
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] START'
+
+declare
+     @return int = 0
+    ,@sql nvarchar(max)
+    ,@header_sql nvarchar(max)
+    ,@filelist_sql nvarchar(max)
+    ,@restore_sql nvarchar(max)
+    ,@default_data_path nvarchar(4000)
+    ,@default_log_path nvarchar(4000)
+    ,@sql_version varchar(20) = convert(varchar(20), serverproperty('productversion'))
+    ,@multi_path bit = 0
+    ,@first_full_path nvarchar(4000)
+
+create table #headeronly
+(
+     BackupName nvarchar(128) null
+    ,BackupDescription nvarchar(255) null
+    ,BackupType smallint null
+    ,ExpirationDate datetime null
+    ,Compressed bit null
+    ,Position smallint null
+    ,DeviceType tinyint null
+    ,UserName nvarchar(128) null
+    ,ServerName nvarchar(128) null
+    ,DatabaseName nvarchar(128) null
+    ,DatabaseVersion int null
+    ,DatabaseCreationDate datetime null
+    ,BackupSize numeric(20,0) null
+    ,FirstLSN numeric(25,0) null
+    ,LastLSN numeric(25,0) null
+    ,CheckpointLSN numeric(25,0) null
+    ,DatabaseBackupLSN numeric(25,0) null
+    ,BackupStartDate datetime null
+    ,BackupFinishDate datetime null
+    ,SortOrder smallint null
+    ,[CodePage] smallint null
+    ,UnicodeLocaleId int null
+    ,UnicodeComparisonStyle int null
+    ,CompatibilityLevel tinyint null
+    ,SoftwareVendorId int null
+    ,SoftwareVersionMajor int null
+    ,SoftwareVersionMinor int null
+    ,SoftwareVersionBuild int null
+    ,MachineName nvarchar(128) null
+    ,Flags int null
+    ,BindingID uniqueidentifier null
+    ,RecoveryForkID uniqueidentifier null
+    ,Collation nvarchar(128) null
+    ,FamilyGUID uniqueidentifier null
+    ,HasBulkLoggedData bit null
+    ,IsSnapshot bit null
+    ,IsReadOnly bit null
+    ,IsSingleUser bit null
+    ,HasBackupChecksums bit null
+    ,IsDamaged bit null
+    ,BeginsLogChain bit null
+    ,HasIncompleteMetaData bit null
+    ,IsForceOffline bit null
+    ,IsCopyOnly bit null
+    ,FirstRecoveryForkID uniqueidentifier null
+    ,ForkPointLSN numeric(25,0) null
+    ,RecoveryModel nvarchar(60) null
+    ,DifferentialBaseLSN numeric(25,0) null
+    ,DifferentialBaseGUID uniqueidentifier
+    ,BackupTypeDescription nvarchar(60) null
+    ,BackupSetGUID uniqueidentifier null
+    ,CompressedBackupSize numeric(20,0) null
+    --,Containment tinyint not null -- SQL 2012+
+)
+
+-- SQL 2012+ added a new column
+if left(@sql_version, charindex('.', @sql_version) - 1) >= 11
+begin
+    alter table #headeronly add Containment tinyint not null
+end
+
+create table #filelistonly
+(
+     ident int not null identity(1, 1) primary key clustered
+    ,LogicalName varchar(255) null
+    ,PhysicalName varchar(255) null
+    ,[Type] char(1) null
+    ,FileGroupName varchar(50) null
+    ,Size bigint null
+    ,MaxSize bigint null
+    ,FileId int null
+    ,CreateLSN numeric(30,2) null
+    ,DropLSN numeric(30,2) null
+    ,UniqueId uniqueidentifier null
+    ,ReadOnlyLSN numeric(30,2) null
+    ,ReadWriteLSN numeric(30,2) null
+    ,BackupSizeInBytes bigint null
+    ,SourceBlockSize int null
+    ,FileGroupId int null
+    ,LogGroupGUID uniqueidentifier null
+    ,DifferentialBaseLSN numeric(30,2) null
+    ,DifferentialBaseGUID uniqueidentifier null
+    ,IsReadOnly int null
+    ,IsPresent int null
+    ,TDEThumbprint varchar(10) null
+)
+
+declare @filelistonly table
+(
+     ident int not null primary key clustered
+    ,LogicalName varchar(255) null
+    ,PhysicalName varchar(255) null
+    ,[Type] char(1) null
+    ,FileGroupName varchar(50) null
+    ,FileId int null
+    ,FileGroupId int null
+    ,NewLogicalName varchar(255) null
+    ,NewPhysicalName varchar(255) null
+    ,Directory varchar(255) null
+)
+
+select
+     @sql_data_directory = nullif(@sql_data_directory, N'')
+    ,@sql_log_directory = nullif(@sql_log_directory, N'')
+    ,@sql_ft_directory = nullif(@sql_ft_directory, N'')
+
+--====================================================================================================
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] Running rp_case_drop on [' + @database_name + ']'
+
+-- By setting @debug to 255 you can skip the drop. Useful when you want to spit out the SQL at the bottom without actually running anything.
+if @debug <> 255
+begin
+    exec master.dbo.rp_case_drop
+         @database_name = @database_name
+        ,@debug = @debug
+end
+
+--====================================================================================================
+
+if charindex(',', @full_path) > 0
+begin
+    set @multi_path = 1
+
+    -- Grab the first path
+    select @first_full_path = Item from master.dbo.rf_split_8k_string_single_delimiter(@full_path, ',') where ItemNumber = 1
+end
+else
+begin
+    set @first_full_path = @full_path
+end
+
+--====================================================================================================
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] Getting headers from ' + @full_path
+
+select
+     @header_sql = N'RESTORE HEADERONLY FROM DISK = N''<<@first_full_path>>''; '
+    ,@header_sql = replace(@header_sql, N'<<@first_full_path>>', @first_full_path)
+
+if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] @header_sql: ' + isnull(@header_sql, N'{null}')
+
+insert #headeronly
+    exec(@header_sql)
+
+if @debug >= 3 select '#headeronly before' as '#headeronly', * from #headeronly
+
+if @file_number is null or @file_number < 1
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] Getting maximum file_number (position)'
+
+    select @file_number = max(position) from #headeronly
+end
+
+--====================================================================================================
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] Getting filelist from ' + @first_full_path
+
+select
+     @filelist_sql = N'RESTORE FILELISTONLY FROM DISK = N''<<@first_full_path>>'' WITH FILE = <<@file_number>>; '
+    ,@filelist_sql = replace(@filelist_sql, N'<<@first_full_path>>', @first_full_path)
+    ,@filelist_sql = replace(@filelist_sql, N'<<@file_number>>', @file_number)
+
+if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] @filelist_sql: ' + isnull(@filelist_sql, '{null}')
+
+-- Don't need everything returned by FILELISTONLY but do need to add some additional columns for processing. Easier to just insert into another table (@filelistonly) instead of altering temp table.
+insert #filelistonly
+    exec(@filelist_sql)
+
+if @debug >= 6 select '#filelistonly' as '#filelistonly', * from #filelistonly
+
+insert @filelistonly (ident, LogicalName, PhysicalName, [Type], FileGroupName, FileId, FileGroupId)
+    select ident, LogicalName, PhysicalName, [Type], FileGroupName, FileId, FileGroupId from #filelistonly
+
+if @debug >= 3 select '@filelistonly before' as '@filelistonly', * from @filelistonly
+
+--====================================================================================================
+
+if @sql_data_directory is null or @sql_log_directory is null or @sql_ft_directory is null
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] Find the default data and log paths'
+
+    exec master.dbo.rp_get_default_database_location
+         @default_data_path = @default_data_path output
+        ,@default_log_path = @default_log_path output
+        ,@debug = @debug
+
+    if @sql_data_directory is null set @sql_data_directory = @default_data_path
+    if @sql_log_directory is null set @sql_log_directory = @default_log_path
+    if @sql_ft_directory is null set @sql_ft_directory = @default_log_path
+
+    if @debug >= 1
+    begin
+        print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] @sql_data_directory: ' + isnull(@sql_data_directory, N'{null}')
+        print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] @sql_log_directory: ' + isnull(@sql_log_directory, N'{null}')
+        print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] @sql_ft_directory: ' + isnull(@sql_ft_directory, N'{null}')
+    end
+end
+
+--====================================================================================================
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] Setting SQL paths and database logical names'
+
+update @filelistonly set Directory = '<<@sql_data_directory>>', NewLogicalName = '<<@database_name>>', NewPhysicalName = '<<@database_name>>.mdf' where [type] = 'D' and FileGroupName = 'PRIMARY' and FileId = 1
+update @filelistonly set Directory = '<<@sql_data_directory>>', NewLogicalName = '<<@database_name>>_audit', NewPhysicalName = '<<@database_name>>_audit.ndf' where [type] = 'D' and FileGroupName = 'AUDIT'
+update @filelistonly set Directory = '<<@sql_data_directory>>', NewLogicalName = '<<@database_name>>_indexes', NewPhysicalName = '<<@database_name>>_indexes.ndf' where [type] = 'D' and FileGroupName = 'INDEXES'
+update @filelistonly set Directory = '<<@sql_data_directory>>', NewLogicalName = '<<@database_name>>_data', NewPhysicalName = '<<@database_name>>_data.ndf' where [type] = 'D' and FileGroupName = 'DATA'
+update @filelistonly set Directory = '<<@sql_log_directory>>', NewLogicalName = '<<@database_name>>_log', NewPhysicalName = '<<@database_name>>_log.ldf' where [type] = 'L' and FileGroupId = 0
+update @filelistonly set Directory = '<<@sql_ft_directory>>', NewLogicalName = '<<@database_name>>_fulltext', NewPhysicalName = '<<@database_name>>_fulltext.ndf' where [type] = 'F' or FileGroupName like '%OtherTables%' or LogicalName like 'ftrow[_]%'
+update @filelistonly set Directory = '<<@sql_data_directory>>', NewLogicalName = '<<@database_name>>_temp_storage', NewPhysicalName = '<<@database_name>>_temp_storage.ndf' where [type] = 'D' and FileGroupName like '%Temp_Storage%'
+
+if @debug >= 2 select '@filelistonly after' as '@filelistonly', * from @filelistonly
+
+--====================================================================================================
+
+-- Check for multiple file paths
+if @multi_path = 1
+begin
+    set @restore_sql = N'RESTORE DATABASE [<<@database_name>>] FROM DISK = N''<<@first_full_path>>'''
+
+    select @restore_sql = @restore_sql + N', DISK = N''' + Item + '''' from master.dbo.rf_split_8k_string_single_delimiter(@full_path, ',') where ItemNumber > 1
+
+    set @restore_sql = @restore_sql + N' WITH FILE = <<@file_number>>'
+end
+else
+begin
+    set @restore_sql = N'RESTORE DATABASE [<<@database_name>>] FROM DISK = N''<<@first_full_path>>'' WITH FILE = <<@file_number>>'
+end
+
+select @restore_sql = @restore_sql + ', MOVE N''' + LogicalName + ''' TO N''' + Directory + '' + NewPhysicalName + ''''
+from @filelistonly
+
+select
+     @restore_sql = @restore_sql + ', NOUNLOAD, REPLACE, STATS = 10'
+    ,@restore_sql = replace(@restore_sql, N'<<@database_name>>', @database_name)
+    ,@restore_sql = replace(@restore_sql, N'<<@first_full_path>>', @first_full_path)
+    ,@restore_sql = replace(@restore_sql, N'<<@file_number>>', @file_number)
+    ,@restore_sql = replace(@restore_sql, N'<<@sql_data_directory>>', master.dbo.rf_directory_slash(null, @sql_data_directory, N'\'))
+    ,@restore_sql = replace(@restore_sql, N'<<@sql_log_directory>>', master.dbo.rf_directory_slash(null, @sql_log_directory, N'\'))
+    ,@restore_sql = replace(@restore_sql, N'<<@sql_ft_directory>>', master.dbo.rf_directory_slash(null, @sql_ft_directory, N'\'))
+
+if @debug >= 3 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] @restore_sql (2): ' + isnull(@restore_sql, N'{null}')
+
+if @restore_sql is null
+begin
+    raiserror('@restore_sql is null', 16, 1)
+    return -1
+end
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] Restoring database [' + @database_name + ']'
+
+if @debug <> 255 exec sp_executesql @restore_sql
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_restore] END'
+
+return @return
+
+go
+
+grant exec on dbo.rp_case_restore to public
+go
+
+/* DEV TESTING
+
+exec master.dbo.rp_case_restore
+     @database_name = 'Longford'
+    ,@full_path = 'D:\Software\Ringtail\Databases\Longford\Longford_8_08_011.bak' -- has 2 file numbers
+    ,@sql_data_directory = 'D:\SQL\Data'
+    ,@sql_log_directory = 'D:\SQL\Log'
+    ,@sql_ft_directory = 'D:\SQL\FT'
+    ,@file_number = 2
+    ,@debug = 9
+
+exec master.dbo.rp_case_restore
+     @database_name = 'RestoreTesting'
+    ,@full_path = 'D:\Software\Ringtail\Databases\Longford\Longford_8_08_011.bak' -- has 2 file numbers
+    ,@debug = 255
+
+*/

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_upgrade.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_case_upgrade.sql
@@ -1,0 +1,170 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_case_upgrade') is not null
+begin
+    drop procedure dbo.rp_case_upgrade
+end
+go
+
+create procedure dbo.rp_case_upgrade
+(
+     @database_name nvarchar(128)               -- [Required] If the database doesn't exist then we'll call rp_case_upgrade.
+    ,@username nvarchar(128)                    -- [Required] Used by rp_case_create if the case doesn't exist.
+    ,@ringtail_app_version varchar(25) = null   -- [Optional] If null then we'll use the most recent SQL Components
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+set xact_abort on
+set transaction isolation level read uncommitted
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_upgrade] START'
+
+declare
+     @return int = 0
+    ,@sql_component_path nvarchar(2000)
+    ,@sql nvarchar(max)
+
+set @ringtail_app_version = nullif(@ringtail_app_version, '')
+
+--====================================================================================================
+
+/* Don't try to run this on a CE or DW database */
+
+if @database_name like '%[_]CE' or @database_name like '%[_]DW'
+begin
+    set @return = -1
+    raiserror('Database [%s] can not be upgraded directly. Upgrade the Case instead.', 16, 1, @database_name)
+    return @return
+end
+
+--====================================================================================================
+
+/* Validate the @ringtail_app_version */
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_upgrade] Running rp_get_sql_components.'
+
+exec master.dbo.rp_get_sql_components
+     @sql_component_path = @sql_component_path output
+    ,@ringtail_app_version = @ringtail_app_version output
+    ,@debug = @debug
+
+if @sql_component_path is null
+begin
+    raiserror('Could not find a valid SQL Component path.', 16, 1)
+    return @return
+end
+
+--====================================================================================================
+
+/* If the database doesn't exist we will create it */
+
+if not exists (select 1 from sys.databases where name = @database_name)
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_upgrade] [' + @database_name + '] does not exist. Calling rp_case_upgrade.'
+
+    exec master.dbo.rp_case_create
+         @database_name = @database_name
+        ,@username = @username
+        ,@ringtail_app_version = @ringtail_app_version
+        ,@debug = @debug
+
+    return @return
+end
+
+--====================================================================================================
+
+/* Install the Bootstrap procedures */
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_upgrade] Running rp_install_bootstrap on database [' + @database_name + ']'
+
+exec master.dbo.rp_install_bootstrap
+     @database_name = @database_name
+    ,@ringtail_app_version = @ringtail_app_version
+    ,@sql_component_path = @sql_component_path
+    ,@debug = @debug
+
+--====================================================================================================
+
+/* Install Ringtail scripts */
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_upgrade] Install Ringtail scripts on database [' + @database_name + ']'
+
+/* This section comes from the top of the DatabaseBootstrap.sql file, "Usage example for database upgrade.", in case you need to update to a newer version. */
+set @sql = N'
+use [<<@database_name>>];
+
+select ''<<@database_name>> before'' as [before upgrade], * from dbo.list_variables where thelabel in (''dbModel'',''dbScriptModel'',''productionModel'',''RingtailApplicationVersion'')
+
+-- resolve database type
+declare @dbType varchar(40), @path varchar(400), @reference xml, @ringtailModel varchar(255)
+set @ringtailModel = ''<<@ringtail_app_version>>''
+if object_id(''dbo.list_variables'',''u'') is not null select @dbType = left(theValue,charindex('' '',theValue)) from dbo.list_variables where theLabel = ''dbModel''
+select @dbType = case left(@dbType,2) when ''ca'' then ''case'' when ''po'' then ''portal'' when ''rs'' then ''temp'' when ''rp'' then ''rpf'' end
+if @dbType is null raiserror(''Database type unknown.'',11,1)
+
+-- load input parameter and run
+select @path = [path] from rs_tempdb.dbo.sqlcomponent_path where version = @ringtailModel
+set @reference = ''<reference><targetpath>'' + @path + ''Scripts\'' + @dbType + ''</targetpath></reference>''
+
+exec dbo.rs_sp_database__upgrade @reference
+
+select ''<<@database_name>> after'' as [after upgrade], * from dbo.list_variables where thelabel in (''dbModel'',''dbScriptModel'',''productionModel'',''RingtailApplicationVersion'')
+
+if exists (select 1 from sys.tables where name = ''upgrade'')
+begin
+    if exists (select 1 from dbo.upgrade where steplabel in (''fatal'', ''error''))
+    begin
+        select ''<<@database_name>>'' as ''<<@database_name>>'', * from dbo.upgrade where steplabel in (''fatal'', ''error'')
+    end
+end;
+'
+
+select
+     @sql = replace(@sql, '<<@database_name>>', @database_name)
+    ,@sql = replace(@sql, '<<@ringtail_app_version>>', @ringtail_app_version)
+
+if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_upgrade] @sql: ' + isnull(@sql, '{null}')
+
+if @debug <> 255
+    exec sp_executesql @sql
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_case_upgrade] END'
+
+return @return
+
+go
+
+grant exec on dbo.rp_case_upgrade to public
+go
+
+/* DEV TESTING
+
+exec master.dbo.rp_case_upgrade
+     @database_name = 'eyjnhdgcn szadfadfsazdf'
+    ,@username = 'webuser'
+    ,@password = 'brnnUSA'
+    ,@ringtail_app_version = '8.4.000.58'
+    ,@debug = 9
+
+exec master.dbo.rp_case_upgrade
+     @database_name = 'eyjnhdgcn szadfadfsazdf'
+    ,@username = 'webuser'
+    ,@password = 'brnnUSA'
+    ,@debug = 9
+
+*/

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_get_default_database_location.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_get_default_database_location.sql
@@ -1,0 +1,148 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_get_default_database_location') is not null
+begin
+    drop procedure dbo.rp_get_default_database_location
+end
+go
+
+create procedure dbo.rp_get_default_database_location
+(
+     @default_data_path nvarchar(1000) = null output
+    ,@default_log_path nvarchar(1000) = null output
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+set xact_abort on
+set transaction isolation level read uncommitted
+
+/* Borrowed and modified from: http://www.dbi-services.com/index.php/blog/entry/sql-server-how-to-find-default-data-path */
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_default_database_location] START'
+
+declare
+     @position int
+    ,@instance_name nvarchar(128)
+    ,@registry_path nvarchar(128)
+    ,@registry_key nvarchar(max)
+    ,@database_name nvarchar(128)
+    ,@sql nvarchar(1000)
+    ,@sql_params nvarchar(200)
+
+create table #instance_registry_path
+(
+     instance_name nvarchar(128)
+    ,registry_path nvarchar(128)
+)
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_default_database_location] Trying SERVERPROPERTY method'
+
+-- If SQL Server 2012...
+select
+     @default_data_path = convert(nvarchar(128), serverproperty('instancedefaultdatapath'))
+    ,@default_log_path = convert(nvarchar(128), serverproperty('instancedefaultlogpath'))
+
+if @default_data_path is null
+begin
+    /* Must be SQL Server 2005 through 2008 */
+
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_default_database_location] Trying registry method'
+
+    -- Get the instance name
+    set @position = charindex('\', @@servername)
+
+    if @position = 0
+        set @instance_name = N'MSSQLSERVER'
+    else
+        set @instance_name = substring(@@servername, @position + 1, len(@@servername))
+
+    -- Pull the default path from the registry
+    insert #instance_registry_path
+        exec master.sys.xp_instance_regenumvalues N'HKEY_LOCAL_MACHINE', N'SOFTWARE\\Microsoft\\Microsoft SQL Server\\Instance Names\\SQL'
+
+    select @registry_path = registry_path from #instance_registry_path where @instance_name = instance_name
+
+    set @registry_key = N'SOFTWARE\Microsoft\Microsoft SQL Server\' + @registry_path + N'\MSSQLServer'
+
+    exec master.sys.xp_regread N'HKEY_LOCAL_MACHINE', @registry_key, N'DefaultData', @default_data_path output
+    exec master.sys.xp_regread N'HKEY_LOCAL_MACHINE', @registry_key, N'DefaultLog', @default_log_path output
+
+    if @default_data_path is null
+    begin
+        /* Wow, either something's *really* wrong or you're using a very old version of SQL Server! */
+        
+        if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_default_database_location] Trying any user database method'
+
+        -- Look for the most recent, non-system database and see what they are using.
+        select top 1 @database_name = name from sys.databases where database_id > 4 and name not in ('ReportServer', 'ReportServerTempDB') order by create_date desc
+
+        if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_default_database_location] Getting physical_name from database [' + @database_name + ']'
+
+        select
+             @sql_params = N'@default_data_path nvarchar(1000) output, @default_log_path nvarchar(1000) output'
+            ,@sql = N'select top 1 @default_data_path = physical_name from [<<@database_name>>].sys.database_files where type = 0; select top 1 @default_log_path = physical_name from [<<@database_name>>].sys.database_files where type = 1;'
+            ,@sql = replace(@sql, '<<@database_name>>', @database_name)
+
+        exec sp_executesql
+             @sql, @sql_params
+            ,@default_data_path = @default_data_path output
+            ,@default_log_path = @default_log_path output
+
+        if @default_data_path is null
+        begin
+            /* I guess we'll just use master. And if you don't have THAT then I'm out. */
+
+            if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_default_database_location] Trying master database method'
+
+            select
+                 @sql_params = N'@default_data_path nvarchar(1000) output, @default_log_path nvarchar(1000) output'
+                ,@sql = N'select top 1 @default_data_path = physical_name from [master].sys.database_files where type = 0; select top 1 @default_log_path = physical_name from [master].sys.database_files where type = 1;'
+
+            exec sp_executesql
+                 @sql, @sql_params
+                ,@default_data_path = @default_data_path output
+                ,@default_log_path = @default_log_path output
+        end
+
+        select
+             @default_data_path = reverse(stuff(reverse(@default_data_path), 1, charindex('\', reverse(@default_data_path)), ''))
+            ,@default_log_path = reverse(stuff(reverse(@default_log_path), 1, charindex('\', reverse(@default_log_path)), ''))
+    end
+end
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_default_database_location] END'
+
+return
+
+go
+
+/* DEV TESTING
+
+declare
+     @default_data_path nvarchar(1000)
+    ,@default_log_path nvarchar(1000)
+    ,@debug tinyint = 9
+
+exec master.dbo.rp_get_default_database_location
+     @default_data_path = @default_data_path output
+    ,@default_log_path = @default_log_path output
+    ,@debug = @debug
+
+select @default_data_path as default_data_path, @default_log_path as default_log_path
+
+*/

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_get_sql_components.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_get_sql_components.sql
@@ -1,0 +1,165 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_get_sql_components') is not null
+begin
+    drop procedure dbo.rp_get_sql_components
+end
+go
+
+create procedure dbo.rp_get_sql_components
+(
+     @sql_component_path nvarchar(2000) = null output   -- [Output] The full path to the Scripts folder.
+    ,@ringtail_app_version varchar(25) = null output    -- [Output] The SQL Component version number.
+    ,@bypass_table bit = 0                              -- [Optional] Bypass the SQLComponent_Path table and just use the most recent install on the file system.
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+--set xact_abort on -- disabled on purpose.
+set transaction isolation level read uncommitted
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_sql_components] START'
+
+declare
+     @return int = 0
+    ,@xp_cmdshell varchar(2000)
+    ,@ringtail_path nvarchar(2000) = 'C:\Program Files\Ringtail'
+
+declare @output table
+(
+     ident int not null identity(1,1) primary key clustered
+    ,value nvarchar(max) null
+)
+
+if @bypass_table = 0
+begin
+    /* Look in the rs_tempdb.dbo.SQLComponent_Path table for the most recent valid row first */
+
+    select top 1
+         @sql_component_path = [path]
+        ,@ringtail_app_version = [version]
+    from
+        rs_tempdb.dbo.SQLComponent_Path
+    where
+        valid = 1
+    order by
+        id desc
+
+    exec master.dbo.rp_validate_path
+         @path = @sql_component_path
+        ,@debug = @debug
+
+    /* If there are no valid installs, try the most recent "invalid" install */
+
+    if @sql_component_path is null or @return <> 0
+    begin
+        select top 1
+             @sql_component_path = [path]
+            ,@ringtail_app_version = [version]
+        from
+            rs_tempdb.dbo.SQLComponent_Path
+        order by
+            id desc
+
+        exec master.dbo.rp_validate_path
+             @path = @sql_component_path
+            ,@debug = @debug
+    end
+end
+
+/* If the SQLComponent_Path isn't working see if there's anything on the file system
+Q. Why would this ever happen?
+A. Sometimes I create a fake copy of the components for testing and I don't put it in the SQLComponent_Path table.
+*/
+
+if @bypass_table = 1 or @sql_component_path is null or @return <> 0
+begin
+    if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_sql_components] Running rp_validate_path to check for the "' + @ringtail_path + '" folder'
+
+    -- Make sure the Ringtail folder exists
+    exec master.dbo.rp_validate_path
+         @path = @ringtail_path
+        ,@debug = @debug
+
+    if @return = 0
+    begin
+        if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_sql_components] Finding the latest SQL Components'
+    
+        set @xp_cmdshell = 'dir "C:\Program Files\Ringtail\" /O:-D'
+
+        if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_sql_components] @xp_cmdshell: ' + isnull(@xp_cmdshell, N'{null}')
+
+        insert @output (value)
+            exec xp_cmdshell @xp_cmdshell
+
+        if @debug >= 4 select '@output' as 'rp_get_sql_components @output', * from @output
+
+        select top 1
+            @ringtail_app_version = substring(value, charindex('SQL Component_v', value) + 15, 25)
+        from
+            @output
+        where
+            value like '%SQL Component[_]v%'
+
+        set @sql_component_path = @ringtail_path + N'\SQL Component_v' + @ringtail_app_version
+
+        -- Make sure the SQL Component path exists
+        exec master.dbo.rp_validate_path
+             @path = @sql_component_path
+            ,@debug = @debug
+    end
+end
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_get_sql_components] END'
+
+return @return
+
+go
+
+grant exec on dbo.rp_get_sql_components to public
+go
+
+/* DEV TESTING
+
+declare
+     @return int = 0
+    ,@sql_component_path nvarchar(2000)
+    ,@ringtail_app_version varchar(25)
+     
+exec master.dbo.rp_get_sql_components
+     @sql_component_path = @sql_component_path output
+    ,@ringtail_app_version = @ringtail_app_version output
+    ,@bypass_table = 0
+    ,@debug = 0
+
+select
+     @sql_component_path as sql_component_path
+    ,@ringtail_app_version as ringtail_app_version
+    ,@return as [return]
+
+exec master.dbo.rp_get_sql_components
+     @sql_component_path = @sql_component_path output
+    ,@ringtail_app_version = @ringtail_app_version output
+    ,@bypass_table = 1
+    ,@debug = 0
+
+select
+     @sql_component_path as sql_component_path
+    ,@ringtail_app_version as ringtail_app_version
+    ,@return as [return]
+
+*/

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_install_bootstrap.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_install_bootstrap.sql
@@ -1,0 +1,132 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_install_bootstrap') is not null
+begin
+    drop procedure dbo.rp_install_bootstrap
+end
+go
+
+create procedure dbo.rp_install_bootstrap
+(
+     @database_name nvarchar(128)               -- [Required] Case/Portal/RPF database name.
+    ,@ringtail_app_version varchar(25) = null   -- [Optional/Required] The SQL Components version number. Supply @ringtail_app_version or @sql_component_path.
+    ,@sql_component_path nvarchar(2000) = null  -- [Optional/Required] The full path to the Scripts folder. Supply @ringtail_app_version or @sql_component_path
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+set xact_abort on
+set transaction isolation level read uncommitted
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_install_bootstrap] START'
+
+declare
+     @return int = 0
+    ,@xp_cmdshell varchar(2000)
+    ,@sql nvarchar(max)
+    ,@server_name nvarchar(128) = @@servername
+
+-- Handle zero-length (empty) strings
+select
+     @sql_component_path = nullif(@sql_component_path, '')
+    ,@ringtail_app_version = nullif(@ringtail_app_version, '')
+
+if @debug >= 3 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_install_bootstrap] @sql_component_path: ' + isnull(@sql_component_path, '{null}')
+if @debug >= 3 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_install_bootstrap] @ringtail_app_version: ' + isnull(@ringtail_app_version, '{null}')
+
+--====================================================================================================
+
+if not exists (select 1 from sys.databases where name = @database_name)
+begin
+    set @return = -1
+    raiserror('Database [%s] does not exist.', 16, 1, @database_name)
+    return @return
+end
+
+--====================================================================================================
+
+if @sql_component_path is null and @ringtail_app_version is null
+begin
+    set @return = -1
+    raiserror('Please supply @ringtail_app_version or @sql_component_path.', 16, 1)
+    return @return
+end
+
+if @sql_component_path is null and @ringtail_app_version is not null
+begin
+    select @sql_component_path = [path] from rs_tempdb.dbo.SQLComponent_Path where valid = 1 and [version] = @ringtail_app_version
+
+    if @sql_component_path is /* STILL */ null
+    begin
+        -- This section won't be used much. It would only happen if you are going to try to install SQL Components that weren't installed or got corrupted in the SQL Component table somehow.
+        exec master.dbo.rp_get_sql_components
+             @sql_component_path = @sql_component_path output
+            ,@ringtail_app_version = @ringtail_app_version
+            ,@bypass_table = 1
+            ,@debug = @debug
+    end
+end
+
+--====================================================================================================
+
+/* Validate the SQL Component path */
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_install_bootstrap] Running rp_validate_path to verify path to "' + @sql_component_path + '"'
+
+exec master.dbo.rp_validate_path
+     @path = @sql_component_path
+    ,@debug = @debug
+
+-- Make sure @sql_component_path has an ending slash
+select @sql_component_path = master.dbo.rf_directory_slash(null, @sql_component_path, '\')
+
+--====================================================================================================
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_install_bootstrap] Run DatabaseBootstrap.sql'
+
+select
+     @xp_cmdshell = 'sqlcmd -E -S "<<@server_name>>" -d "<<@database_name>>" -I -i "<<@sql_component_path>>Scripts\DatabaseBootstrap.sql"'
+    ,@xp_cmdshell = replace(@xp_cmdshell, '<<@server_name>>', @server_name)
+    ,@xp_cmdshell = replace(@xp_cmdshell, '<<@database_name>>', @database_name)
+    ,@xp_cmdshell = replace(@xp_cmdshell, '<<@sql_component_path>>', @sql_component_path)
+
+if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_install_bootstrap] @xp_cmdshell: ' + isnull(@xp_cmdshell, '{null}')
+
+if @debug >= 5
+    exec xp_cmdshell @xp_cmdshell
+else
+    exec xp_cmdshell @xp_cmdshell, 'no_output'
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_install_bootstrap] END'
+
+return @return
+
+go
+
+grant exec on dbo.rp_install_bootstrap to public
+go
+
+/* DEV TESTING
+
+exec master.dbo.rp_install_bootstrap
+     @database_name = 'Longford'
+    ,@ringtail_app_version = null
+    ,@sql_component_path = null
+    ,@debug = 1
+
+*/
+

--- a/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_validate_path.sql
+++ b/src/InstallerCommandSuite/AutoDeploy/DataCamel/Sql/rp_validate_path.sql
@@ -1,0 +1,85 @@
+-- Written by Greg (Lord Duffcakes) Duffie
+--
+
+--C# will automatically connect to master, no need for this
+--use master
+--go
+
+if object_id('dbo.rp_validate_path') is not null
+begin
+    drop procedure dbo.rp_validate_path
+end
+go
+
+create procedure dbo.rp_validate_path
+(
+     @path nvarchar(4000)
+    ,@debug tinyint = 0
+)
+with encryption
+as
+
+set nocount on
+--set xact_abort on -- disabled on purpose.
+set transaction isolation level read uncommitted
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_validate_path] START'
+
+/* Suggested @debug values
+1 = Simple print statements
+2 = Simple select statements (e.g. select @variable_1 as variable_1, @variable_2 as variable_2)
+3 = Result sets from temp tables (e.g. select '#temp_table_name' as '#temp_table_name' from #temp_table_name where ...)
+4 = @sql statements from exec() or sp_executesql
+*/
+
+declare
+     @return int = 0
+    ,@xp_cmdshell varchar(2000)
+
+declare @output table
+(
+     ident int not null identity(1,1) primary key clustered
+    ,value nvarchar(max) null
+)
+
+--====================================================================================================
+
+select
+     @xp_cmdshell = 'dir "<<@path>>"'
+    ,@xp_cmdshell = replace(@xp_cmdshell, '<<@path>>', @path)
+
+if @debug >= 4 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_validate_path] @xp_cmdshell: ' + isnull(@xp_cmdshell, N'{null}')
+
+insert @output (value)
+    exec xp_cmdshell @xp_cmdshell
+
+if @debug >= 4 select '@output' as 'rp_validate_path @output', * from @output
+
+if exists (select 1 from @output where value in ('The system cannot find the path specified.', 'File Not found'))
+begin
+    set @return = -1
+    raiserror('The system cannot find the path specified. Is "%s" correct?', 16, 1, @path)
+    return @return
+end
+
+if @debug >= 1 print '[' + convert(varchar(23), getdate(), 121) + '] [rp_validate_path] END'
+
+return @return
+
+go
+
+grant exec on dbo.rp_validate_path to public
+go
+
+/* DEV TESTING
+
+declare @return int = 0
+
+exec @return = master.dbo.rp_validate_path
+     @path = 'C:\Program Files\Ringtail\SQL Component_v8.5.000.143xxxxxxxx'
+    ,@debug = 0
+
+print @return
+
+*/
+


### PR DESCRIPTION
Included the SQL files that were excluded from the default .gitignore.  This includes updates to DataCamel upgrade scripts for refactoring purposes. As a result version was bumped to 1.3.1.