### PR TITLE
Fixes InstallFetcher to work with only files in folder

### DIFF
--- a/src/InstallerCommandSuite/AutoDeploy/InstallFetcher/App/FolderHelpers.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/InstallFetcher/App/FolderHelpers.cs
@@ -100,10 +100,12 @@ namespace InstallFetcher.App
             {
                 Console.WriteLine("    ....folder exists: " + root);
                 var folders = rootFolder.GetDirectories();
+                var files = rootFolder.GetFiles(); 
 
-                if (folders.Length > 0)
-                {
+                if (folders.Length > 0 || files.Length > 0)
+                {                       
                     DirectoryInfo finalFolder = GetFirstFolderWithFiles(rootFolder, options.FolderSuffix);
+
                     if (finalFolder != null)
                     {
                         string realPath = finalFolder.FullName;
@@ -126,13 +128,13 @@ namespace InstallFetcher.App
                 }
                 else
                 {
-                    Console.WriteLine("The target folder was accessible, but no builds have been made yet: " + options.FolderRoot);
+                    Console.WriteLine("The target folder was accessible, but no builds have been made yet: " + root);
                     Environment.Exit(1);
                 }
             }
             else
             {
-                Console.WriteLine("The target folder was not accessible or not found: " + options.FolderRoot);
+                Console.WriteLine("The target folder was not accessible or not found: " + root);
                 Environment.Exit(1);
             }
 

--- a/src/InstallerCommandSuite/Shared/VersionInfo.cs
+++ b/src/InstallerCommandSuite/Shared/VersionInfo.cs
@@ -9,5 +9,5 @@ using System.Runtime.InteropServices;
 //      Bug fix
 //      0
 //
-[assembly: AssemblyVersion("2.1.4.0")]
-[assembly: AssemblyFileVersion("2.1.4.0")]
+[assembly: AssemblyVersion("2.1.5.0")]
+[assembly: AssemblyFileVersion("2.1.5.0")]


### PR DESCRIPTION
Fixes InstallFetcher to work when there are no sub-folders but there are files in the root path of the destination folder.  

Bumped vesrion to 2.1.5