### PR TITLE
Converted RPF Coordinator to use a configurable uninstall

### DIFF
--- a/src/InstallerCommandSuite/AutoDeploy/Configs/commands.config
+++ b/src/InstallerCommandSuite/AutoDeploy/Configs/commands.config
@@ -3,6 +3,7 @@ DatabaseUpgrader.exe~DatabaseUpgrader|DATACAMEL_ACTION|-u IS_SQLSERVER_USERNAME|
 InstallFetcher.exe|-f BUILD_FOLDER_ROOT|-b BRANCH_NAME|-o Everything
 InstallFetcher.exe~RingtailLegalApplicationServer|-f BUILD_FOLDER_ROOT|-b BRANCH_NAME|-o RingtailLegalApplicationServer
 UninstallerHelper.exe *
+UninstallerHelper.exe * uninstall-rpfcoordinator.bat ~RingtailProcessingFramework|UNINSTALL_EXCLUSIONS
 GenericInstaller.exe Ringtail8
 GenericInstaller.exe RingtailConfigurator
 GenericInstaller.exe RingtailDatabaseUtility

--- a/src/InstallerCommandSuite/AutoDeploy/Configs/masterCommands.config
+++ b/src/InstallerCommandSuite/AutoDeploy/Configs/masterCommands.config
@@ -17,8 +17,9 @@ iisreset.exe
 |RingtailLegalApplicationServer
 iisreset.exe
 |Uninstall_ALL
-UninstallerHelper.exe *
 uninstall.bat
+|Uninstall_RpfCoordinator
+uninstaller-rpfcoordinator.bat
 |CUSTOM_UNINSTALL
 uninstallRingtail.bat
 |RingtailDatabaseUtility

--- a/src/InstallerCommandSuite/AutoDeploy/Configs/roles.config
+++ b/src/InstallerCommandSuite/AutoDeploy/Configs/roles.config
@@ -31,7 +31,7 @@ RPF-SUPERVISOR|Uninstall_ALL
 RPF-COORDINATOR|RingtailProcessingFramework
 RPF-COORDINATOR|RingtailProcessingFrameworkWorkers
 RPF-COORDINATOR|Deployer
-RPF-COORDINATOR|Uninstall_ALL
+RPF-COORDINATOR|Uninstall_RpfCoordinator
 
 DATABASE|RingtailDatabaseUtility
 DATABASE|Uninstall_ALL

--- a/src/InstallerCommandSuite/AutoDeploy/UninstallerHelper/App/UninstallCommandGenerator.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/UninstallerHelper/App/UninstallCommandGenerator.cs
@@ -9,7 +9,7 @@ namespace UninstallerHelper.App
 {
     public class UninstallCommandGenerator
     {
-        internal static string CreateUninstallString(RegistryKey app, string matchBy)
+        internal static string CreateUninstallString(RegistryKey app, string matchBy, string[] exclusions)
         {
             var uninstallString = string.Empty;
             var hasUninstallString = !String.IsNullOrEmpty(app.GetValueNames().ToList().Find(x => x == "UninstallString"));
@@ -18,20 +18,19 @@ namespace UninstallerHelper.App
             if (hasUninstallString && hasAppName)
             {
                 var appName = app.GetValue("DisplayName").ToString();
+                var isExclusion = exclusions != null ? exclusions.Any(p => appName.Contains(p)) : false;
 
-                if (appName.Contains(matchBy) || String.IsNullOrEmpty(matchBy))
+                if (!isExclusion && (appName.Contains(matchBy) || String.IsNullOrEmpty(matchBy)))
                 {
                     var registryUnintallString = app.GetValue("UninstallString").ToString();
                     var type = appName.Contains("Configurator") ? "partial" : "complete";
                     type = appName.Contains("Framework Workers") ? "wmic" : type;
                     uninstallString = AddArgumentsToUninstallString(registryUnintallString, type, appName);
-
                 }
             }
 
             return uninstallString;
-        }
-
+        }        
 
         private static string AddArgumentsToUninstallString(string uninstall, string type, string appName)
         {

--- a/src/InstallerCommandSuite/AutoDeploy/UninstallerHelper/Program.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/UninstallerHelper/Program.cs
@@ -30,15 +30,32 @@ namespace UninstallerHelper
                     matchBy = args[0];
                 }
 
-                ringtailKeys.ForEach(z => allUninstallStrings.Add(UninstallCommandGenerator.CreateUninstallString(z, matchBy)));
+                string outputFile = "uninstall.bat";
+                if (args.Length > 1)
+                {
+                    outputFile = args[1];
+                }
+
+                string[] exclusions = null;
+                if (args.Length > 2)
+                {
+                    var exclusionStrings = args[2];
+                    var exclusionParts = exclusionStrings.Split(',');
+                    exclusions = exclusionParts
+                        .Select(p => p.Trim())
+                        .Where(p => !string.IsNullOrEmpty(p))
+                        .ToArray();
+                }
+
+                ringtailKeys.ForEach(z => allUninstallStrings.Add(UninstallCommandGenerator.CreateUninstallString(z, matchBy, exclusions)));
                 allUninstallStrings.ForEach(x => Console.WriteLine(x));                
 
-                l.AddAndWrite("Writing uninstall.bat");
-                SimpleFileWriter.Write("uninstall.bat", allUninstallStrings);
+                l.AddAndWrite("Writing " + outputFile);
+                SimpleFileWriter.Write(outputFile, allUninstallStrings);
 
-                if (!new FileInfo("uninstall.bat").Exists)
+                if (!new FileInfo(outputFile).Exists)
                 {
-                    l.AddAndWrite("Failed to write uninstall.bat");
+                    l.AddAndWrite("Failed to write " + outputFile);
                     exitCode = 1;
                 }
                 if (allUninstallStrings.Count == 0)


### PR DESCRIPTION
The main problem was making the service capable of performing partial uninstalls. This approach uses volitleData.config to add application exclusions from the uninstall script on a role by role basis.

This changes the RPF-COORDINATOR role to no longer execute the Uninstall_All command.  Instead this role will execute the Uninstall_RpfCoordinator command as defined in masterCommands.config.

The Uninstall_RpfCoordinator command executes the uninstall-rfpcoordinator.bat instead of uninstaller.bat.

This bat file is created by the UninstallerHelper.exe, that now accepts two additional arguments.  Argument 2 is the output file.  Argument 3 is the product name exclusions.

When UninstallHelper.exe executes with these argument it will use the exclusion list, as a comma delimited list of strings, to excluded uninstall commands for products that are a wildcard match of exclusion list. 

This is glued together in commands.config with a new entry that calls UninstallerHelper.exe with uninstall-rpfcoordinator.bat and the config key for RingtailProcessingFramework|UNINSTALL_EXCLUSIONS

This key can be optionally set in volitleData.config to "Framework Workers" to prevent the the RPF Coordinator from uninstall the RPF Workers.