### PR TITLE
Added file cleanup helper

### DIFF
--- a/src/InstallerCommandSuite/AutoDeploy/Configs/commands.config
+++ b/src/InstallerCommandSuite/AutoDeploy/Configs/commands.config
@@ -4,6 +4,7 @@ InstallFetcher.exe|-f BUILD_FOLDER_ROOT|-b BRANCH_NAME|-o Everything
 InstallFetcher.exe~RingtailLegalApplicationServer|-f BUILD_FOLDER_ROOT|-b BRANCH_NAME|-o RingtailLegalApplicationServer
 UninstallerHelper.exe *
 UninstallerHelper.exe * uninstall-rpfcoordinator.bat ~RingtailProcessingFramework|UNINSTALL_EXCLUSIONS
+FileCleaner.exe -l FileCleaner-rpf.txt -o cleaner-rpf.bat -s ~RingtailProcessingFramework|FILE_DELETIONS
 GenericInstaller.exe Ringtail8
 GenericInstaller.exe RingtailConfigurator
 GenericInstaller.exe RingtailDatabaseUtility

--- a/src/InstallerCommandSuite/AutoDeploy/Configs/masterCommands.config
+++ b/src/InstallerCommandSuite/AutoDeploy/Configs/masterCommands.config
@@ -22,7 +22,7 @@ uninstall.bat
 uninstaller-rpfcoordinator.bat
 |CUSTOM_UNINSTALL
 uninstallRingtail.bat
-|RpfFileCleaner
+|RingtailProcessingFramework
 cleaner-rpf.bat
 |RingtailDatabaseUtility
 install-RingtailDatabaseUtility.bat

--- a/src/InstallerCommandSuite/AutoDeploy/Configs/masterCommands.config
+++ b/src/InstallerCommandSuite/AutoDeploy/Configs/masterCommands.config
@@ -22,6 +22,8 @@ uninstall.bat
 uninstaller-rpfcoordinator.bat
 |CUSTOM_UNINSTALL
 uninstallRingtail.bat
+|RpfFileCleaner
+cleaner-rpf.bat
 |RingtailDatabaseUtility
 install-RingtailDatabaseUtility.bat
 dbUp.bat

--- a/src/InstallerCommandSuite/AutoDeploy/FileCleaner/CleanerHelper.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/FileCleaner/CleanerHelper.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileCleaner
+{
+    public class CleanerHelper
+    {
+        public Options Options { get; set; }
+        public StringBuilder Log { get; set; }
+        public StringBuilder Output { get; set; }
+
+        public CleanerHelper(Options options)
+        {
+            this.Options = options;
+            this.Log = new StringBuilder();
+            this.Output = new StringBuilder();
+        }
+
+        public int Process()
+        {
+            var exitCode = 0 | ProcessPaths() | ProcessSubs();
+
+            if (this.Output.Length > 0)
+            {
+                this.Output.AppendLine("IF ERRORLEVEL 1 SET ERRORLEV=0");
+                this.Output.AppendLine("IF ERRORLEVEL 2 SET ERRORLEV=0");
+                this.Output.AppendLine("IF ERRORLEVEL 3 SET ERRORLEV=0");
+                this.Output.AppendLine("IF ERRORLEVEL 4 SET ERRORLEV=0");
+                this.Output.AppendLine("IF ERRORLEVEL 5 SET ERRORLEV=0");
+            }
+            else
+            {
+                this.Output.AppendLine("@echo NOTHING TO CLEAN");
+            }
+
+            return exitCode;
+        }
+
+        int ProcessPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return 0;            
+            
+            var exitCode = 0;
+            path = path.Trim();
+            this.Log.AppendLine(string.Format("Processing '{0}'", path));
+            try
+            {
+                var attr = File.GetAttributes(path);
+                if (attr.HasFlag(FileAttributes.Directory))
+                    this.Output.AppendLine(string.Format("rd /S /Q \"{0}\"", path));
+                else
+                    this.Output.AppendLine(string.Format("del /F /Q \"{0}\"", path));
+                exitCode = 0;
+            }
+            catch (Exception ex)
+            {
+                this.Log.AppendLine("ERROR");
+                this.Log.AppendLine("  -> " + ex.Message);
+                exitCode = 2;
+            }            
+
+            return exitCode;
+        }
+
+        int ProcessPaths()
+        {
+            if (this.Options.Paths == null)
+                return 0;            
+
+            var exitCode = 0;
+            foreach (var rawPath in this.Options.Paths)
+            {
+                if (rawPath == "FILE_DELETIONS")
+                    return exitCode;
+
+                exitCode = exitCode | ProcessPath(rawPath);
+            }
+            return exitCode;
+        }
+
+        int ProcessSubs()
+        {
+            if (this.Options.Subs == null)
+                return 0;
+
+            var exitCode = 0;
+            foreach (var rawRoot in this.Options.Subs)
+            {
+                if (rawRoot == "FILE_DELETIONS")
+                    return exitCode;
+
+                if (string.IsNullOrWhiteSpace(rawRoot))
+                    continue;
+
+                var root = rawRoot.Trim();
+                this.Log.AppendFormat("Finding subdirectories for '{0}'", root);
+                try
+                {
+                    // find the directories
+                    var paths = Directory.GetDirectories(root);
+
+                    // output a deletion line for each directory
+                    foreach (var path in paths)                                            
+                        ProcessPath(path);                    
+                }
+                catch (Exception ex)
+                {
+                    this.Log.AppendLine("ERROR");
+                    this.Log.AppendLine("  -> " + ex.Message);
+                    exitCode = exitCode | 2;
+                }
+            }
+            return exitCode;
+        }
+
+        public string WriteLog()
+        {
+            using (StreamWriter sw = new StreamWriter(this.Options.LogFile))
+            {
+                var text = this.Log.ToString();
+                sw.Write(text);
+                return text;
+            }
+        }
+
+        public string WriteOutput()
+        {
+            using (StreamWriter sw = new StreamWriter(this.Options.OutFile))
+            {
+                var text = this.Output.ToString();
+                sw.Write(text);
+                return text;
+            }
+        }
+    }
+}

--- a/src/InstallerCommandSuite/AutoDeploy/FileCleaner/FileCleaner.csproj
+++ b/src/InstallerCommandSuite/AutoDeploy/FileCleaner/FileCleaner.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FileCleaner</RootNamespace>
+    <AssemblyName>FileCleaner</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\AutoDeploy\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="CommandLine">
+      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Shared\VersionInfo.cs">
+      <Link>Properties\VersionInfo.cs</Link>
+    </Compile>
+    <Compile Include="CleanerHelper.cs" />
+    <Compile Include="Options.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>del $(TargetDir)$(ProjectName).pdb</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/InstallerCommandSuite/AutoDeploy/FileCleaner/Options.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/FileCleaner/Options.cs
@@ -1,0 +1,33 @@
+﻿using CommandLine;
+using CommandLine.Text;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileCleaner
+{    
+    public class Options
+    {        
+        [OptionList('f', "paths", Separator= ',', HelpText = "The comma separated list of files or folders to delete")]
+        public IList<string> Paths { get; set; }
+
+        [OptionList('s', "subs", Separator = ',', HelpText = "The comma separated list of root directories where all sub-folders will be deleted")]
+        public IList<string> Subs { get; set; }
+
+        [Option('o', "out", Required = true, HelpText = "The output batch file that will be created")]
+        public string OutFile { get; set; }
+
+        [Option('l', "log", Required = true, HelpText = "The log file")]
+        public string LogFile { get; set; }        
+
+        [HelpOption]
+        public string GetUsage()
+        {
+            var autogen = HelpText.AutoBuild(this, (HelpText current) => HelpText.DefaultParsingErrorsHandler(this, current));
+            return "\r\nThis program creates a script file that will delete the specified files and directories.\r\n\r\n" + autogen; 
+        }
+    }
+
+}

--- a/src/InstallerCommandSuite/AutoDeploy/FileCleaner/Program.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/FileCleaner/Program.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+
+namespace FileCleaner
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {               
+            var options = new Options();
+            if(!CommandLine.Parser.Default.ParseArguments(args, options))
+            {                
+                return 1;
+            }
+
+            var cleaner = new CleanerHelper(options);            
+            var exitCode = cleaner.Process();
+            Console.WriteLine(cleaner.WriteLog());
+            cleaner.WriteOutput();
+
+            Console.WriteLine("Exiting with code " + exitCode);
+            return exitCode;
+        }
+    }    
+}

--- a/src/InstallerCommandSuite/AutoDeploy/FileCleaner/Properties/AssemblyInfo.cs
+++ b/src/InstallerCommandSuite/AutoDeploy/FileCleaner/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FileCleaner")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FileCleaner")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a4a46ec3-5507-436d-8df9-98cebce89117")]

--- a/src/InstallerCommandSuite/AutoDeploy/FileCleaner/packages.config
+++ b/src/InstallerCommandSuite/AutoDeploy/FileCleaner/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
+</packages>

--- a/src/InstallerCommandSuite/AutoDeploy/RingtailAutoInstaller.sln
+++ b/src/InstallerCommandSuite/AutoDeploy/RingtailAutoInstaller.sln
@@ -38,58 +38,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{804BDC
 		..\Shared\VersionInfo.cs = ..\Shared\VersionInfo.cs
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileCleaner", "FileCleaner\FileCleaner.csproj", "{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}"
+EndProject
 Global
-	GlobalSection(TeamFoundationVersionControl) = preSolution
-		SccNumberOfProjects = 16
-		SccEnterpriseProvider = {4CA58AB2-18FA-4F8D-95D4-32DDF27D184C}
-		SccTeamFoundationServer = http://tfs2012.dev.tech.local:8080/tfs/fticollection
-		SccLocalPath0 = .
-		SccProjectUniqueName1 = Composer\\Composer.csproj
-		SccProjectName1 = Composer
-		SccLocalPath1 = Composer
-		SccProjectUniqueName2 = DatabaseUpgrader\\DatabaseUpgrader.csproj
-		SccProjectName2 = DatabaseUpgrader
-		SccLocalPath2 = DatabaseUpgrader
-		SccProjectUniqueName3 = GenericInstaller\\GenericInstaller.csproj
-		SccProjectName3 = GenericInstaller
-		SccLocalPath3 = GenericInstaller
-		SccProjectUniqueName4 = InstallFetcher\\InstallFetcher.csproj
-		SccProjectName4 = InstallFetcher
-		SccLocalPath4 = InstallFetcher
-		SccProjectUniqueName5 = InstallNameTruncator\\InstallNameTruncator.csproj
-		SccProjectName5 = InstallNameTruncator
-		SccLocalPath5 = InstallNameTruncator
-		SccProjectUniqueName6 = RingtailAutoInstaller\\Master.csproj
-		SccProjectName6 = RingtailAutoInstaller
-		SccLocalPath6 = RingtailAutoInstaller
-		SccProjectUniqueName7 = Deployer\\Deployer.csproj
-		SccProjectName7 = Deployer
-		SccLocalPath7 = Deployer
-		SccProjectUniqueName8 = InstallerTests\\InstallerTests.csproj
-		SccProjectName8 = InstallerTests
-		SccLocalPath8 = InstallerTests
-		SccProjectUniqueName9 = RoleResolver\\RoleResolver.csproj
-		SccProjectName9 = RoleResolver
-		SccLocalPath9 = RoleResolver
-		SccProjectUniqueName10 = RegCleaner\\RegistryReader.csproj
-		SccProjectName10 = RegCleaner
-		SccLocalPath10 = RegCleaner
-		SccProjectUniqueName11 = ConfiguratorHelper\\ConfiguratorHelper.csproj
-		SccProjectName11 = ConfiguratorHelper
-		SccLocalPath11 = ConfiguratorHelper
-		SccProjectUniqueName12 = DataCamel\\DataCamel.csproj
-		SccProjectName12 = DataCamel
-		SccLocalPath12 = DataCamel
-		SccProjectUniqueName13 = MasterRunner\\MasterRunner.csproj
-		SccProjectName13 = MasterRunner
-		SccLocalPath13 = MasterRunner
-		SccProjectUniqueName14 = UninstallerHelper\\UninstallerHelper.csproj
-		SccProjectName14 = UninstallerHelper
-		SccLocalPath14 = UninstallerHelper
-		SccProjectUniqueName15 = RequiredConfigurationsGenerator\\RequiredConfigurationsGenerator.csproj
-		SccProjectName15 = RequiredConfigurationsGenerator
-		SccLocalPath15 = RequiredConfigurationsGenerator
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
@@ -249,6 +200,16 @@ Global
 		{B6CC9F23-007D-47BA-8F49-236FBA118442}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{B6CC9F23-007D-47BA-8F49-236FBA118442}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B6CC9F23-007D-47BA-8F49-236FBA118442}.Release|Win32.ActiveCfg = Release|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{A28E7347-1ABA-4F32-B7EA-2BF9D6F091B9}.Release|Win32.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
FileCleanup is a simple application that takes a list of paths and creates a deletion script from the supplied paths.

This is necessary to add support for wiping the RPF_Supervisor path of the existing workers so that new workers can be copied down from the Coordinator after installation.

masterCommand.config and commands.config were modified to accept a new volitleData.config,  FILE_DELETIONS.  This key is used by RPF, and if supplied, the file cleanup helper will build a script that contains directories to delete.

If the value is not supplied it will build a script that executes without failure.

Finally, the script does not fail if it is unable to delete something.