### PR TITLE
Lets you specify the .net runtime version

### DIFF
--- a/src/AutoDeploy/DeployToIIS/App/Options.cs
+++ b/src/AutoDeploy/DeployToIIS/App/Options.cs
@@ -25,6 +25,11 @@ namespace DeployToIIS
         public string InstallPath { get; set; }
 
 
+        [Option('v', "runtimeVersion", Required = false, DefaultValue ="v4.0", HelpText = "CLR Versions")]
+        public string ManagedRuntimeVersion { get; set; }
+
+
+
         [HelpOption]
         public string GetUsage()
         {

--- a/src/AutoDeploy/DeployToIIS/App/Program.cs
+++ b/src/AutoDeploy/DeployToIIS/App/Program.cs
@@ -55,6 +55,7 @@ namespace DeployToIIS
                                 appPool.ProcessModel.UserName = options.Username;
                                 appPool.ProcessModel.Password = options.Password;
                                 appPool.ProcessModel.IdentityType = ProcessModelIdentityType.SpecificUser;
+                                appPool.ManagedRuntimeVersion = options.ManagedRuntimeVersion;
                             }
                         }
 


### PR DESCRIPTION
Default was v2.0 - which is not very helpful, so I changed the default
to v4.0 and made it so you could pass in v2.0 if you had to.