### PR TITLE
Adds task-level timeouts.

### DIFF
--- a/src/AutoDeploy/MasterRunner/App/Options.cs
+++ b/src/AutoDeploy/MasterRunner/App/Options.cs
@@ -13,18 +13,22 @@ namespace MasterRunner.App
         [Option('f', "file", Required = true, HelpText = "File to execute")]
         public string FileName { get; set; }
 
-        [Option('d', "workingFolder", DefaultValue= "",  HelpText = "location of the batch file")]
+        [Option('d', "workingFolder", DefaultValue = "", HelpText = "location of the batch file")]
         public string WorkingFolder { get; set; }
 
         [Option('o', "output", DefaultValue = "buildOutput.txt", HelpText = "log to file")]
         public string OutputFile { get; set; }
 
         [Option('u', "user", HelpText = "domain and user to execute runas command")]
-        public string User { get; set;}
+        public string User { get; set; }
 
-        [Option('p', "password", HelpText= "password to execute runas command")]
+        [Option('p', "password", HelpText = "password to execute runas command")]
         public string Password { get; set; }
-        
+
+
+        [Option('t', "defaultTaskTimeout", DefaultValue = 600000, Required = false, HelpText = "default task timeout length")]
+        public int Timeout { get; set; }
+
         [HelpOption]
         public string GetUsage()
         {

--- a/src/AutoDeploy/MasterRunner/App/Runner.cs
+++ b/src/AutoDeploy/MasterRunner/App/Runner.cs
@@ -11,7 +11,7 @@ namespace MasterRunner.App
 {
     public class RunnerFactory
     {
-        public static IRunner MakeRunner(string logFile, string fileName, string workingFolder, string username, string password)
+        public static IRunner MakeRunner(string logFile, string fileName, string workingFolder, string username, string password, int defaultTimeout)
         {
             Logger logger = new Logger();
             logger.fileName = logFile;
@@ -25,7 +25,7 @@ namespace MasterRunner.App
             if (fileName.Contains(".bat"))
             {
                 Console.WriteLine("Spawning: BatchFileRunner: " + fileName);
-                return new BatchFileRunner(logger, SimpleFileReader.Read(fileName), workingFolder, username, password);
+                return new BatchFileRunner(logger, SimpleFileReader.Read(fileName), workingFolder, username, password, defaultTimeout);
             }
             if (fileName.Contains(".exe"))
             {

--- a/src/AutoDeploy/MasterRunner/App/Runners/BatchFileRunner.cs
+++ b/src/AutoDeploy/MasterRunner/App/Runners/BatchFileRunner.cs
@@ -14,14 +14,16 @@ namespace MasterRunner.App.Runners
         private Logger logger;
         private string username;
         private string password;
+        private int defaultTimeout;
 
-        public BatchFileRunner(Logger logger, List<string> fileContents, string workingFolder, string username, string password)
+        public BatchFileRunner(Logger logger, List<string> fileContents, string workingFolder, string username, string password, int defaultTimeout)
         {
             this.logger = logger;
             this.fileContents = fileContents;
             this.workingFolder = workingFolder;
             this.username = username;
             this.password = password;
+            this.defaultTimeout = defaultTimeout;
         }
 
         public int RunFile()
@@ -34,7 +36,7 @@ namespace MasterRunner.App.Runners
             }
 
             var allowedExits = SimpleFileReader.Read(workingFolder + "allowedExit.config");
-            ProcessExecutorHelper helper = new ProcessExecutorHelper(logger, allowedExits);
+            ProcessExecutorHelper helper = new ProcessExecutorHelper(logger, allowedExits, SimpleFileReader.Read("timeout.config"), defaultTimeout);
 
 
             if (allowedExits.Count == 0)

--- a/src/AutoDeploy/MasterRunner/App/Runners/ExeFileRunner.cs
+++ b/src/AutoDeploy/MasterRunner/App/Runners/ExeFileRunner.cs
@@ -30,7 +30,7 @@ namespace MasterRunner.App.Runners
             Console.WriteLine("Processing via ExeFileRunner");
 
             var allowedExits = SimpleFileReader.Read(workingFolder + "allowedExit.config");
-            ProcessExecutorHelper helper = new ProcessExecutorHelper(logger, allowedExits);
+            ProcessExecutorHelper helper = new ProcessExecutorHelper(logger, allowedExits, SimpleFileReader.Read("timeout.config"), 10000);
 
             int exitCode = helper.SpawnAndLog(filename, workingFolder, username, password);
             if (exitCode == 0)

--- a/src/AutoDeploy/MasterRunner/App/Runners/PowerShellFileRunner.cs
+++ b/src/AutoDeploy/MasterRunner/App/Runners/PowerShellFileRunner.cs
@@ -44,7 +44,8 @@ namespace MasterRunner.App.Runners
             Console.WriteLine("Processing via PowerShellRunner");
 
             var allowedExits = SimpleFileReader.Read(workingFolder + "allowedExit.config");
-            ProcessExecutorHelper helper = new ProcessExecutorHelper(logger, allowedExits);
+
+            ProcessExecutorHelper helper = new ProcessExecutorHelper(logger, allowedExits, SimpleFileReader.Read("timeout.config"), 10000);
 
             int exitCode = helper.SpawnAndLog("PowerShell.exe -ExecutionPolicy Bypass -File " + filename, workingFolder, username, password);
             if (exitCode == 0)

--- a/src/AutoDeploy/MasterRunner/Program.cs
+++ b/src/AutoDeploy/MasterRunner/Program.cs
@@ -22,7 +22,7 @@ namespace MasterRunner
                 {
                     options.WorkingFolder = Environment.CurrentDirectory + @"\";
                     Console.WriteLine("running: " + options.WorkingFolder + options.FileName);
-                    exitCode = RunnerFactory.MakeRunner(options.OutputFile, options.FileName, options.WorkingFolder, options.User, options.Password).RunFile();
+                    exitCode = RunnerFactory.MakeRunner(options.OutputFile, options.FileName, options.WorkingFolder, options.User, options.Password, options.Timeout).RunFile();
                 }
             }
             catch


### PR DESCRIPTION
Task level timeouts - default task timeout of 10 minutes.  Can pass in a
different default timeout as a parameter.   Can also have a
"timeout.config" file that allows for per-task whitelisting of timeouts,
with a magic number of '0' for infinite.

Will soon want to add on a 'coure-correct' section in here, so if the
timeout is tripped, we can have a whitelist of a 'cleanup and retry
task'.