### PR TITLE
Reverting to a sync task runner for deployments

### DIFF
--- a/src/AutoDeploy/Deployer/App/DeploymentRunner.cs
+++ b/src/AutoDeploy/Deployer/App/DeploymentRunner.cs
@@ -45,16 +45,14 @@ namespace Deployer.App
                     exit = 0;
                     var x = filesToDeploy[i];
 
-                    var retryMax = 100;         // i know - this is a really high number.  our IIS deployments are junk, and sometimes the big ones take a bunch of times to work right.
-                                                // under the hood, they're writing to applicationHost.config at the same time IIS is trying to write to the same file and it's a 100kb file.
-                                                // and that causes the OS to be sad.
+                    var retryMax = 3;
                     var fileName = x.Split('\\');
                     var friendlyName = fileName[fileName.Length - 1];
 
                     Console.WriteLine(" " + friendlyName + "   " + (i + 1) + " of " + filesToDeploy.Count);
 
                     int j = 1;
-                    ProcessOutcome exitInfo = null;
+                    int exitInfo = 0;
                     for (; j <= retryMax; j++)
                     {
 
@@ -62,14 +60,16 @@ namespace Deployer.App
                         string batchPath = "runDeployments-" + i + ".bat";
 
                         log.AddAndWrite("About to deploy: " + x, logFileName);
-                        var batchContents = GenerateDeploymentCommand(x, myBatch);  // writes to myBatch.   bad API here, sorry.
+                        var batchContents = RunDeployment(x, myBatch);  // writes to myBatch.   bad API here, sorry.
                         log.AddAndWrite(batchContents, logFileName);
 
                         SimpleFileWriter.Write(batchPath, myBatch);
 
-                        exitInfo = RunFile(batchPath, x, log);
 
-                        if (exitInfo.ExitCode == 0)
+                        exitInfo = ProcessRunner.RunFileMOD(batchPath, x, log).ExitCode;
+
+
+                        if (exitInfo == 0)
                         {
                             break;
                         }
@@ -77,19 +77,13 @@ namespace Deployer.App
                         {
                             int retryWaitTime = 10 * j;     // it turns out wait time between these is irrelevent.... it just needs to try a bunch of times until it gets lucky and works.
                             Console.WriteLine("  Retrying deployment " + j + " of " + retryMax + " attempts in " + retryWaitTime / 1000 + " seconds");
-                            
+
                             System.Threading.Thread.Sleep(retryWaitTime);  // wait progressively longer for the gremilns to go away.
                         }
 
                         if (j == retryMax)
                         {
                             exit = 2;
-
-                            if (exitInfo != null)
-                            {
-                                Console.WriteLine(exitInfo.Error);
-                                break;
-                            }
                         }
                     }
 
@@ -127,142 +121,7 @@ namespace Deployer.App
             return exit;
         }
 
-
-        private static ProcessOutcome RunFile(string file, string appFullName, Logger log)
-        {
-            int exitCode = 0;
-
-            bool ranOk = true;
-
-            StringBuilder errorText = new StringBuilder();
-
-            StringBuilder output = new StringBuilder();
-            StringBuilder error = new StringBuilder();
-
-            using (AutoResetEvent outputWaitHandle = new AutoResetEvent(false))
-            using (AutoResetEvent errorWaitHandle = new AutoResetEvent(false))
-            {
-                using (var process = new System.Diagnostics.Process())
-                {
-                    process.StartInfo.FileName = "cmd.exe";
-                    process.StartInfo.Arguments = " /c " + file;
-                    process.StartInfo.WorkingDirectory = Environment.CurrentDirectory;
-                    process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Normal;
-                    process.StartInfo.RedirectStandardOutput = true;
-                    process.StartInfo.RedirectStandardError = true;
-                    process.StartInfo.UseShellExecute = false;
-                    process.Start();
-
-
-                    //http://stackoverflow.com/questions/139593/processstartinfo-hanging-on-waitforexit-why
-                    process.OutputDataReceived += (sender, e) =>
-                    {
-                        if (e.Data == null)
-                        {
-                            outputWaitHandle.Set();
-                        }
-                        else
-                        {
-                            if (e.Data.StartsWith("Total"))
-                            {
-                                string s = e.Data.Length > 30 ? e.Data.Substring(0, 25) + "..." : e.Data;
-                                s = s.Split('(')[0];
-                                output.AppendLine(" " + s);
-                            } 
-                        }
-                    };
-                    process.ErrorDataReceived += (sender, e) =>
-                    {
-                        if (e.Data == null)
-                        {
-                            errorWaitHandle.Set();
-                        }
-                        else
-                        {
-                            if (e.Data.StartsWith("The system"))
-                            {
-                                exitCode = 0;
-                                ranOk = true;
-                            }
-                            else
-                            {
-                                log.AddToLog(" " + e.Data);
-                                
-
-                                if(e.Data.StartsWith("Error:" ))
-                                {
-                                    string tmp = e.Data.Replace("Error:", string.Empty);
-                                    error.AppendLine(tmp);
-                                }
-                                else
-                                {
-                                    error.AppendLine(e.Data);
-                                }
-
-
-                                if (e.Data.StartsWith("Error count:"))
-                                {
-                                    ranOk = false;
-                                    exitCode = 2;
-                                }
-                            }
-                        }
-                    };
-
-                    Stopwatch sw = new Stopwatch();
-                    sw.Start();
-
-                    process.Start();
-                    process.BeginOutputReadLine();
-                    process.BeginErrorReadLine();
-
-                    int timeout = 300000;  // 5 minutes for each step out to be enough for anybody.
-
-
-                    if (process.WaitForExit(timeout) &&
-                        outputWaitHandle.WaitOne(timeout) &&
-                        errorWaitHandle.WaitOne(timeout))
-                    {
-                        // Process completed.
-                        if (!ranOk)
-                        {
-                            exitCode = 2;
-                        }
-                    }
-                    else
-                    {
-                        // Timed out.
-                        log.AddToLog("* timed out....");
-                        log.AddToLog("*process took longer than " + timeout + "  ms");
-                        return new ProcessOutcome("Timed out", string.Empty, 1001, false);
-                    }
-
-
-                    if (process.ExitCode == 0 && ranOk)
-                    {
-                        Console.WriteLine( " " + output.ToString().TrimEnd());
-                    }
-                    else
-                    {
-                        //Error: The process cannot access 'C:\\inetpub\\wwwroot\\Coordinator\\312fca79-5f6c-4bc2-820b-59466cedf3d7trace.log' because it is being used by another process.
-                        var fileName = appFullName.Split('\\');
-                        var str = fileName[fileName.Length - 1];
-                        var data = error.ToString();
-
-                        errorText.AppendLine("  Problem with: " + str);
-                        errorText.AppendLine("  ERROR - The IIS deployment for " + str + " did not run correctly.");
-                        errorText.AppendLine("  " + data);
-                    }
-                }
-            }
-
-            ProcessOutcome outcome = new ProcessOutcome(errorText.ToString(), String.Empty, exitCode, ranOk);
-
-
-            return outcome;
-        }
-
-        public static List<string> GenerateDeploymentCommand(string file, List<string> myBatch)
+        public static List<string> RunDeployment(string file, List<string> myBatch)
         {
             var log = new List<string>();
             log.Add(" attempting to run deployment: " + file);
@@ -338,6 +197,69 @@ namespace Deployer.App
         }
     }
 
+
+    public class ProcessRunner
+    {
+        public static ProcessOutcome RunFileMOD(string file, string appFullName, Logger log)
+        {
+            int exitCode = 0;
+
+            var process = new System.Diagnostics.Process();
+            process.StartInfo.FileName = "cmd.exe";
+            process.StartInfo.Arguments = " /c " + file;
+
+            process.StartInfo.WorkingDirectory = Environment.CurrentDirectory;
+            process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Normal;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.UseShellExecute = false;
+            process.Start();
+            string output = process.StandardOutput.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
+
+
+            Logger outputLog = new Logger();
+            outputLog.AddToLog("Output: ");
+            outputLog.AddToLog(output);
+
+            outputLog.AddToLog("Errors: ");
+            outputLog.AddToLog(error);
+
+            outputLog.Write("log-deploy-" + file.Split('.')[0] + ".txt");
+
+            if (process.ExitCode != 0)
+            {
+                Console.WriteLine("* ran with exit code: " + process.ExitCode);
+            }
+
+            var lines = output.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None).ToList();
+
+            foreach (var x in lines)
+            {
+                if (x.Contains("Total changes:"))
+                {
+                    Console.WriteLine(" " + x);
+                }
+            }
+
+            var errorLines = error.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None).ToList();
+
+            log.AddToLog("* Output: " + output);
+            log.AddToLog("* Errors: \n" + error);
+
+            if (!String.IsNullOrEmpty(error))
+            {
+                exitCode = 1;
+                outputLog.AddToLog("* Errors: \n" + error);
+            }
+
+            outputLog.Write("log-deploy-" + file.Split('.')[0] + ".txt");
+
+            ProcessOutcome po = new ProcessOutcome(string.Empty, string.Empty, exitCode, exitCode == 0);
+            return po;
+        }
+    }
+
     public class ProcessOutcome
     {
         public int ExitCode { get; private set; }
@@ -353,4 +275,7 @@ namespace Deployer.App
             this.ExitOk = exitOk;
         }
     }
+
+
+
 }

--- a/src/AutoDeploy/Deployer/App/DeploymentRunner.cs
+++ b/src/AutoDeploy/Deployer/App/DeploymentRunner.cs
@@ -51,9 +51,8 @@ namespace Deployer.App
 
                     Console.WriteLine(" " + friendlyName + "   " + (i + 1) + " of " + filesToDeploy.Count);
 
-                    int j = 1;
                     int exitInfo = 0;
-                    for (; j <= retryMax; j++)
+                    for (int j = 1; j <= retryMax; j++)
                     {
 
                         List<string> myBatch = new List<string>();


### PR DESCRIPTION
...but still reading the output more cleanly for error trapping.
timeouts still supported via the parent caller.