### PR TITLE
Allow for a global wildcard timeout.

### DIFF
--- a/src/AutoDeploy/MasterRunner/Util/ProcessExecutorHelper.cs
+++ b/src/AutoDeploy/MasterRunner/Util/ProcessExecutorHelper.cs
@@ -288,10 +288,18 @@ namespace MasterRunner.App
                     string nonExtension = commandName.Split('.')[0];
                     var timeout = timeoutList.Find(x => x.Split('|')[0] == nonExtension);
 
+                    var globalTimeout = timeoutList.Find(x => x.Split('|')[0] == "*");
+
                     if (timeout != null && timeout.Length > 0)
                     {
                         logger.AddToLog(" found special timeout: " + timeout);
                         var customTimeout = Convert.ToInt32(timeout.Split('|')[1]);
+                        return customTimeout;
+                    }
+
+                    if (globalTimeout != null && globalTimeout.Length > 0)
+                    {
+                        var customTimeout = Convert.ToInt32(globalTimeout.Split('|')[1]);
                         return customTimeout;
                     }
                 }


### PR DESCRIPTION
It's easier to change the timout.config file than it is to code a
parameter change into MasterRunner.exe .... so make a wildcard *|900000
type of value so that all timeouts use that, unless they have a more
specific custom timeout like 'MySlowrunningExe|1200000000000000'