### PR TITLE
Adding an exception for our own tool.

### DIFF
--- a/src/AutoDeploy/FileCleaner/App/JobCleanupHelper.cs
+++ b/src/AutoDeploy/FileCleaner/App/JobCleanupHelper.cs
@@ -101,6 +101,14 @@ namespace FileCleaner.App
                     }
                 }
 
+                if (x.Name.Contains("RingtailCertificate"))
+                {
+                    // we don't want to delete files from our own tool set.
+                    // in the future, we should probably copy fetch files to a subfolder.
+                    continue;
+                }
+
+
                 filteredFiles.Add(x);
             }
             return filteredFiles;


### PR DESCRIPTION
Users typically delete Ringtail exe's, but RingtailCertificates is our
own part of the tool set, and we don't want to let them delete it.