### PR TITLE
Don't pass passwords for IIS around - just read directly from volitleData

### DIFF
--- a/src/AutoDeploy/DatabaseUpgrader/App/BatchWriter.cs
+++ b/src/AutoDeploy/DatabaseUpgrader/App/BatchWriter.cs
@@ -13,11 +13,11 @@ namespace DatabaseUpgrader.App
             string str = string.Empty;
             if (opts.Actions[0].ToLower() == "upgradeportal")
             {
-                str = "DataCamel.exe " + opts.Actions[0] + " " + Options.ConvertOptionListToSingle(opts.Databases) + " -u " + opts.Username + " -p " + opts.Password;
+                str = "DataCamel.exe " + opts.Actions[0] + " " + Options.ConvertOptionListToSingle(opts.Databases) + " -u " + opts.Username + " -p " + opts.Password + " -m " + opts.Max;
             }
             else
             {
-                str = "DataCamel.exe " + opts.Actions[0] + " -u " + opts.Username + " -p " + opts.Password + " -d " + Options.ConvertOptionListToSingle(opts.Databases);
+                str = "DataCamel.exe " + opts.Actions[0] + " -u " + opts.Username + " -p " + opts.Password + " -d " + Options.ConvertOptionListToSingle(opts.Databases) + " -m " + opts.Max;
             }
 
             var commands = new List<string>();

--- a/src/AutoDeploy/DatabaseUpgrader/App/Options.cs
+++ b/src/AutoDeploy/DatabaseUpgrader/App/Options.cs
@@ -32,6 +32,9 @@ namespace DatabaseUpgrader.App
         [Option('c', "component", HelpText = "The SQL Component version to use, defaults to newest in install path")]
         public string Version { get; set; }
 
+        [Option('m', "max", DefaultValue = "3", HelpText = "The maximum number of concurrent DB upgrades to run at the same time.")]
+        public string Max { get; set; }
+
         [Option('i', "install-path", DefaultValue = @"C:\Program Files\Ringtail", HelpText = "SQL Components install path")]
         public string InstallPath { get; set; }
 

--- a/src/AutoDeploy/DeployToIIS/App/ConfigHelper.cs
+++ b/src/AutoDeploy/DeployToIIS/App/ConfigHelper.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DeployToIIS.App
+{
+    public class ConfigHelper
+    {
+        public static void TryApplyCredentialsToOptions(List<string> volitileData, Options options)
+        {
+            string applicationName = options.AppName;
+            var appConfigs = volitileData.FindAll(x => x.StartsWith(applicationName));
+
+
+            //Ringtail-Svc-ContentSearch|Username="DOMAIN\user"
+            //Ringtail-Svc-ContentSearch|Password="PASSWORD"
+            //Ringtail-Svc-ContentSearch|Version="1"
+            var userKeyValue = appConfigs.Find(x => x.Contains(applicationName + "|SERVICEUSERNAME="));
+            var pwdKeyValue = appConfigs.Find(x => x.Contains(applicationName + "|SERVICEPASSWORD="));
+
+            var user = "";
+            var pwd = "";
+
+            bool includeUserPassword = false;
+            if (!String.IsNullOrEmpty(userKeyValue))
+            {
+                includeUserPassword = true;
+            }
+
+            if (!String.IsNullOrEmpty(pwdKeyValue))
+            {
+                includeUserPassword = true;
+            }
+
+            if (!includeUserPassword)
+            {
+                Console.WriteLine(" Did not find a service username or password for " + " " + applicationName + "|SERVICEPASSWORD=" + " will deploy with ApplicationPoolIdentity.");
+            }
+
+
+            try
+            {
+                if (!String.IsNullOrEmpty(userKeyValue))
+                {
+                    user = userKeyValue.Split('=')[1];
+                    user = user.Substring(1, user.Length - 2);
+
+                    options.Username = user;
+                }
+
+                if (!String.IsNullOrEmpty(pwdKeyValue))
+                {
+                    pwd = pwdKeyValue.Split('=')[1];
+                    pwd = pwd.Substring(1, pwd.Length - 2);
+
+                    options.Password = pwd;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("...error reading configurations: " + ex.Message);
+                throw ex;
+            }
+        }
+    }
+}

--- a/src/AutoDeploy/DeployToIIS/App/Program.cs
+++ b/src/AutoDeploy/DeployToIIS/App/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Web.Administration;
+﻿using DeployToIIS.Util;
+using Microsoft.Web.Administration;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -6,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DeployToIIS
+namespace DeployToIIS.App
 {
     class Program
     {
@@ -21,6 +22,10 @@ namespace DeployToIIS
             if (CommandLine.Parser.Default.ParseArguments(args, options))
             {
                 options.InstallPath = options.InstallPath.Replace("\"", "");
+
+                string volitileData = "volitleData.config";
+                var volitileDataList = SimpleFileReader.Read(volitileData);
+                ConfigHelper.TryApplyCredentialsToOptions(volitileDataList, options);
 
 
                 DirectoryInfo di = new DirectoryInfo(options.InstallPath);
@@ -150,6 +155,8 @@ namespace DeployToIIS
 
             return exitCode;
         }
+
+
 
         private static void SetIdentityToAppPool(Options options, ApplicationPool appPool)
         {

--- a/src/AutoDeploy/DeployToIIS/DeployToIIS.csproj
+++ b/src/AutoDeploy/DeployToIIS/DeployToIIS.csproj
@@ -57,9 +57,11 @@
     <Compile Include="..\..\Shared\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="App\ConfigHelper.cs" />
     <Compile Include="App\Options.cs" />
     <Compile Include="App\Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Util\FileHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/AutoDeploy/DeployToIIS/Util/FileHelpers.cs
+++ b/src/AutoDeploy/DeployToIIS/Util/FileHelpers.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DeployToIIS.Util
+{
+    public class SimpleFileReader
+    {
+        public static List<string> Read(string fileName)
+        {
+            List<string> s = new List<string>();
+
+            FileInfo fi = new FileInfo(fileName);
+            if (fi.Exists)
+            {
+
+                using (StreamReader stream = new StreamReader(fileName))
+                {
+                    string input = null;
+                    while ((input = stream.ReadLine()) != null)
+                    {
+                        s.Add(input);
+                    }
+                }
+            }
+
+            return s;
+        }
+    }
+}

--- a/src/AutoDeploy/InstallerTests/ServiceInstallerTests/ServiceInstallerTest.cs
+++ b/src/AutoDeploy/InstallerTests/ServiceInstallerTests/ServiceInstallerTest.cs
@@ -22,7 +22,7 @@ namespace InstallerTests.ServiceInstallerTests
             var vData = new List<string>();
             vData.Add("Common|RpfDBUser=\"localPortal\"");
             vData.Add("SomeOtherApp|RpfDBUser=\"Junk\"");
-            
+
 
             var newConfig = ConfigHelper.ApplyVolitleDataToConfig("blah", testFile, vData);
             Assert.IsTrue(newConfig[0].Contains("localPortal"), "Should be localPortal");
@@ -32,6 +32,24 @@ namespace InstallerTests.ServiceInstallerTests
             newConfig = ConfigHelper.ApplyVolitleDataToConfig("TESTAPP", testFile, vData);
             Assert.IsTrue(newConfig[0].Contains("alternateKey"), "Should be alternateKey");
 
+        }
+
+        [TestMethod]
+        public void TestGenerateIISInstallCommand_DoesNotPassAuthenticationCreds()
+        {
+            var vData = new List<string>();
+
+            var x = ServiceInstallerHelper.GenerateIISInstallCommand(vData, "MyApp");
+            Console.WriteLine(x);
+
+            Assert.AreEqual(x, "DeployToIIS.exe -a MyApp -i \"C:\\Program Files\\FTI Technology\\MyApp\"", "no matching creds");
+
+            vData = new List<string>();
+            vData.Add("MyApp|SERVICEUSERNAME=\"user\"");
+            vData.Add("MyApp|SERVICEPASSWORD=\"password\"");
+
+            x = ServiceInstallerHelper.GenerateIISInstallCommand(vData, "MyApp");
+            Assert.AreEqual(x, "DeployToIIS.exe -a MyApp -i \"C:\\Program Files\\FTI Technology\\MyApp\"", "creds present");
         }
     }
 }

--- a/src/AutoDeploy/MasterRunner/Util/ProcessExecutorHelper.cs
+++ b/src/AutoDeploy/MasterRunner/Util/ProcessExecutorHelper.cs
@@ -48,20 +48,25 @@ namespace MasterRunner.App
             {
                 logger.AddAndWrite("-----------");
                 logger.AddAndWrite(headerInfo);
-                logger.AddAndWrite("* starting: " + workingFolder + command);
-                //logger.AddAndWrite("* time: " + DateTime.Now);
+
+                var split = command.Split(' ')[0];
+                logger.AddAndWrite("* starting: " + workingFolder + split);
+                DateTime dt = DateTime.Now;
+                
 
                 var result = SpawnProcess(command, workingFolder, username, password);
 
                 if (result.ExitCode != 0 && !result.ExitOk)
                 {
-                    logger.AddAndWrite("* time: " + DateTime.Now);
+                    logger.AddAndWrite("* time started: " + dt);
+                    logger.AddAndWrite("* time ended: " + DateTime.Now);
                     logger.AddAndWrite("* Exited with code " + result.ExitCode);
                     exitCode = result.ExitCode;
                 }
                 else if (result.ExitCode != 0 && result.ExitOk)
                 {
-                    logger.AddAndWrite("* time: " + DateTime.Now);
+                    logger.AddAndWrite("* time started: " + dt);
+                    logger.AddAndWrite("* time ended: " + DateTime.Now);
                     logger.AddAndWrite("* Exited with code " + result.ExitCode);
                     logger.AddAndWrite("* ...but this is a whitelisted exit code for this command");
                     exitCode = 0;

--- a/src/AutoDeploy/ServiceInstaller/App/ServiceInstallerHelper.cs
+++ b/src/AutoDeploy/ServiceInstaller/App/ServiceInstallerHelper.cs
@@ -292,70 +292,71 @@ namespace ServiceInstaller.App
             //Ringtail-Svc-ContentSearch|Username="DOMAIN\user"
             //Ringtail-Svc-ContentSearch|Password="PASSWORD"
             //Ringtail-Svc-ContentSearch|Version="1"
-            var userKeyValue = appConfigs.Find(x => x.Contains(applicationName + "|SERVICEUSERNAME="));
-            var pwdKeyValue = appConfigs.Find(x => x.Contains(applicationName + "|SERVICEPASSWORD="));
+            //var userKeyValue = appConfigs.Find(x => x.Contains(applicationName + "|SERVICEUSERNAME="));
+            //var pwdKeyValue = appConfigs.Find(x => x.Contains(applicationName + "|SERVICEPASSWORD="));
             var installPath = GetInstallPath(applicationName);
 
-            var user = "";
-            var pwd = "";
+            //var user = "";
+            //var pwd = "";
 
 
-            Console.WriteLine("userKeyValue: " + userKeyValue);
+            //Console.WriteLine("userKeyValue: " + userKeyValue);
 
-            bool includeUserPassword = false;
-            if (!String.IsNullOrEmpty(userKeyValue))
-            {
-                //Console.WriteLine(" Missing a required entry in volitleData.config for the key: " + " " + applicationName + "|SERVICEUSERNAME=");
-                includeUserPassword = true;
-            }
+            //bool includeUserPassword = false;
+            //if (!String.IsNullOrEmpty(userKeyValue))
+            //{
+            //    //Console.WriteLine(" Missing a required entry in volitleData.config for the key: " + " " + applicationName + "|SERVICEUSERNAME=");
+            //    includeUserPassword = true;
+            //}
 
-            if (!String.IsNullOrEmpty(pwdKeyValue))
-            {
-                //Console.WriteLine(" Missing a required entry in volitleData.config for the key: " + " " + applicationName + "|SERVICEPASSWORD=");
-                includeUserPassword = true;
-            }
+            //if (!String.IsNullOrEmpty(pwdKeyValue))
+            //{
+            //    //Console.WriteLine(" Missing a required entry in volitleData.config for the key: " + " " + applicationName + "|SERVICEPASSWORD=");
+            //    includeUserPassword = true;
+            //}
 
-            if (!includeUserPassword)
-            {
-                Console.WriteLine(" Did not find a service username or password for " + " " + applicationName + "|SERVICEPASSWORD=" + " will deploy with ApplicationPoolIdentity.");
-            }
+            //if (!includeUserPassword)
+            //{
+            //    Console.WriteLine(" Did not find a service username or password for " + " " + applicationName + "|SERVICEPASSWORD=" + " will deploy with ApplicationPoolIdentity.");
+            //}
 
 
-            try
-            {
-                //Console.WriteLine("...userkeyvalue: " + userKeyValue);
-                //Console.WriteLine("...pwdKeyValue: " + pwdKeyValue);
+            //try
+            //{
+            //    //Console.WriteLine("...userkeyvalue: " + userKeyValue);
+            //    //Console.WriteLine("...pwdKeyValue: " + pwdKeyValue);
 
-                if (!String.IsNullOrEmpty(userKeyValue))
-                {
-                    user = userKeyValue.Split('=')[1];
-                    user = user.Substring(1, user.Length - 2);
-                }
+            //    if (!String.IsNullOrEmpty(userKeyValue))
+            //    {
+            //        user = userKeyValue.Split('=')[1];
+            //        user = user.Substring(1, user.Length - 2);
+            //    }
 
-                if (!String.IsNullOrEmpty(pwdKeyValue))
-                {
-                    pwd = pwdKeyValue.Split('=')[1];
-                    pwd = pwd.Substring(1, pwd.Length - 2);
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("...error reading configurations: " + ex.Message);
-                throw ex;
-            }
+            //    if (!String.IsNullOrEmpty(pwdKeyValue))
+            //    {
+            //        pwd = pwdKeyValue.Split('=')[1];
+            //        pwd = pwd.Substring(1, pwd.Length - 2);
+            //        pwd = pwd.Replace("%", "%%");           // batch files need the have % signs replaced with double %%.
+            //    }
+            //}
+            //catch (Exception ex)
+            //{
+            //    Console.WriteLine("...error reading configurations: " + ex.Message);
+            //    throw ex;
+            //}
 
             //DeployToIIS.exe -u DOMAIN\user -p PASSWORD! -a RingtailSearchSvc -i "C:\Program Files\FTI Technology\Ringtail Search Service"
 
 
             string iisInstall = string.Empty;
-            if (includeUserPassword == true)
-            {
-                iisInstall = String.Format("DeployToIIS.exe -u {0} -p {1} -a {2} -i \"{3}\"", user, pwd, applicationName, installPath);
-            }
-            else
-            {
+            //if (includeUserPassword == true)
+            //{
+            //    iisInstall = String.Format("DeployToIIS.exe -u {0} -p {1} -a {2} -i \"{3}\"", user, pwd, applicationName, installPath);
+            //}
+            //else
+            //{
                 iisInstall = String.Format("DeployToIIS.exe -a {0} -i \"{1}\"", applicationName, installPath);
-            }
+            //}
             return iisInstall;
         }
 

--- a/src/AutoDeploy/ServiceInstaller/App/ServiceInstallerHelper.cs
+++ b/src/AutoDeploy/ServiceInstaller/App/ServiceInstallerHelper.cs
@@ -287,76 +287,9 @@ namespace ServiceInstaller.App
             Console.WriteLine("...starting to generate the IIS installation command");
 
             var appConfigs = volitileData.FindAll(x => x.StartsWith(applicationName));
-
-
-            //Ringtail-Svc-ContentSearch|Username="DOMAIN\user"
-            //Ringtail-Svc-ContentSearch|Password="PASSWORD"
-            //Ringtail-Svc-ContentSearch|Version="1"
-            //var userKeyValue = appConfigs.Find(x => x.Contains(applicationName + "|SERVICEUSERNAME="));
-            //var pwdKeyValue = appConfigs.Find(x => x.Contains(applicationName + "|SERVICEPASSWORD="));
             var installPath = GetInstallPath(applicationName);
 
-            //var user = "";
-            //var pwd = "";
-
-
-            //Console.WriteLine("userKeyValue: " + userKeyValue);
-
-            //bool includeUserPassword = false;
-            //if (!String.IsNullOrEmpty(userKeyValue))
-            //{
-            //    //Console.WriteLine(" Missing a required entry in volitleData.config for the key: " + " " + applicationName + "|SERVICEUSERNAME=");
-            //    includeUserPassword = true;
-            //}
-
-            //if (!String.IsNullOrEmpty(pwdKeyValue))
-            //{
-            //    //Console.WriteLine(" Missing a required entry in volitleData.config for the key: " + " " + applicationName + "|SERVICEPASSWORD=");
-            //    includeUserPassword = true;
-            //}
-
-            //if (!includeUserPassword)
-            //{
-            //    Console.WriteLine(" Did not find a service username or password for " + " " + applicationName + "|SERVICEPASSWORD=" + " will deploy with ApplicationPoolIdentity.");
-            //}
-
-
-            //try
-            //{
-            //    //Console.WriteLine("...userkeyvalue: " + userKeyValue);
-            //    //Console.WriteLine("...pwdKeyValue: " + pwdKeyValue);
-
-            //    if (!String.IsNullOrEmpty(userKeyValue))
-            //    {
-            //        user = userKeyValue.Split('=')[1];
-            //        user = user.Substring(1, user.Length - 2);
-            //    }
-
-            //    if (!String.IsNullOrEmpty(pwdKeyValue))
-            //    {
-            //        pwd = pwdKeyValue.Split('=')[1];
-            //        pwd = pwd.Substring(1, pwd.Length - 2);
-            //        pwd = pwd.Replace("%", "%%");           // batch files need the have % signs replaced with double %%.
-            //    }
-            //}
-            //catch (Exception ex)
-            //{
-            //    Console.WriteLine("...error reading configurations: " + ex.Message);
-            //    throw ex;
-            //}
-
-            //DeployToIIS.exe -u DOMAIN\user -p PASSWORD! -a RingtailSearchSvc -i "C:\Program Files\FTI Technology\Ringtail Search Service"
-
-
-            string iisInstall = string.Empty;
-            //if (includeUserPassword == true)
-            //{
-            //    iisInstall = String.Format("DeployToIIS.exe -u {0} -p {1} -a {2} -i \"{3}\"", user, pwd, applicationName, installPath);
-            //}
-            //else
-            //{
-                iisInstall = String.Format("DeployToIIS.exe -a {0} -i \"{1}\"", applicationName, installPath);
-            //}
+            string iisInstall = String.Format("DeployToIIS.exe -a {0} -i \"{1}\"", applicationName, installPath);
             return iisInstall;
         }
 

--- a/src/Shared/VersionInfo.cs
+++ b/src/Shared/VersionInfo.cs
@@ -9,5 +9,5 @@ using System.Runtime.InteropServices;
 //      Bug fix
 //      0
 //
-[assembly: AssemblyVersion("2.9.4.0")]
-[assembly: AssemblyFileVersion("2.9.4.0")]
+[assembly: AssemblyVersion("2.9.5.0")]
+[assembly: AssemblyFileVersion("2.9.5.0")]


### PR DESCRIPTION
Instead of passing the IIS password around as a parameter, read it from
volitleData.
This improves security and removes encoding issues.
...also adding config for the DatabaseUpgrader so that we can pass
through the arg for the number of concurrent upgrades, with a default of
3.